### PR TITLE
Fix sysroot setting for aarch64 sdk toolchain

### DIFF
--- a/appdev/conf/cmake/toolchain-aarch64.cmake
+++ b/appdev/conf/cmake/toolchain-aarch64.cmake
@@ -4,13 +4,12 @@ set(CMAKE_SYSTEM_PROCESSOR aarch64)
 set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc-11)
 set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++-11)
 
-set(CMAKE_FIND_ROOT_PATH  "/build/sysroot_aarch64")
+set(CMAKE_SYSROOT /build/sysroot_aarch64)
+
+set(CMAKE_FIND_ROOT_PATH "${CMAKE_SYSROOT}")
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
-
-set(CMAKE_C_FLAGS "--sysroot /build/sysroot_aarch64/")
-set(CMAKE_CXX_FLAGS "--sysroot /build/sysroot_aarch64/")
 
 set(ENV{PKG_CONFIG_DIR} "")
 set(ENV{PKG_CONFIG_LIBDIR} "${CMAKE_FIND_ROOT_PATH}/usr/lib/aarch64-linux-gnu/pkgconfig/:${CMAKE_FIND_ROOT_PATH}/usr/share/pkgconfig")


### PR DESCRIPTION
# Changes

Hard setting of CMAKE\_\<LANG\>\_FLAGS in the toolchain file breaks a bunch of valid cmake use-cases, e.g. getting CFLAGS and CXXFLAGS input from the environment.
In cases you need to set something into CMAKE\_<LANG>\_FLAGS in the toolchain file, since CMAKE 3.7 you can set CMAKE\_\<LANG\>\_FLAGS_INIT, which is the recommended way to set flags from the toolchain (and still keep the CMake mechanisms working that take flags from the environment and other places).
Here it is even easier, there is a CMAKE_SYSROOT variable that does what it is supposed to do, i.e. hand in the --sysroot flag to the compiler without overwriting all other flags.