### PR TITLE
appdev: move CMakePresets.json to container and invert include direction

### DIFF
--- a/layers/appdev/conf/cmake/BasePresets.json
+++ b/layers/appdev/conf/cmake/BasePresets.json
@@ -1,0 +1,78 @@
+{
+    "version": 4,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 23
+    },
+    "configurePresets": [
+        {
+            "name": "base",
+            "hidden": true,
+            "generator": "Unix Makefiles",
+            "environment": {
+                "BUILDDIR": "/build/results/apps/$env{APP_NAME}/${presetName}/build",
+                "DESTDIR": "$env{BUILDDIR}/install"
+            },
+            "binaryDir": "$env{BUILDDIR}",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": {
+                    "type": "BOOL",
+                    "value": "TRUE"
+                },
+                "CMAKE_BUILD_TYPE": {
+                    "type": "STRING",
+                    "value": "Debug"
+                }
+            }
+        },
+        {
+            "name": "ebcl-x86_64",
+            "hidden": true,
+            "inherits": "base",
+            "toolchainFile": "/build/cmake/toolchain-x86_64.cmake"
+        },
+        {
+            "name": "ebcl-aarch64",
+            "hidden": true,
+            "inherits": "base",
+            "toolchainFile": "/build/cmake/toolchain-aarch64.cmake"
+        },
+        {
+            "name": "qemu-x86_64",
+            "inherits": "ebcl-x86_64"
+        },
+        {
+            "name": "qemu-aarch64",
+            "inherits": "ebcl-aarch64"
+        },
+        {
+            "name": "hardware",
+            "inherits": "ebcl-aarch64"
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "base",
+            "hidden": true,
+            "jobs": 8,
+            "targets" : [
+                "install"
+            ]
+        },
+        {
+            "name": "qemu-x86_64",
+            "configurePreset": "qemu-x86_64",
+            "inherits": "base"
+        },
+        {
+            "name": "qemu-aarch64",
+            "configurePreset": "qemu-aarch64",
+            "inherits": "base"
+        },
+        {
+            "name": "hardware",
+            "configurePreset": "hardware",
+            "inherits": "base"
+        }
+    ]
+}


### PR DESCRIPTION
The toolchain definitions  are part of the container, so the CMakePresets.json should also be part of the container. This also drops the include of app_presets.json. The include should now be done the other way around, i.e.
 - remove the old symlink to CMakePresets.json
 - rename app_presets.json to CMakePresets.json
 - add "include": [ "/build/cmake/BasePresets.json"]
 - add "inherits": "base" to the configurePreset

This is a more natural include direction and allows adding addition toolchain preset files, that can be referenced in apps using the appropriate include file

# Dependencies:
 none (The "old" implementation still works)
 See Elektrobit/ebcl_template#37 for required changes

# Developer Checklist:
- [x] Test: Changes are tested
- [x] Git: Informative git commit message(s)

# Reviewer checklist:
- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer