### PR TITLE
Integrate embdgen 0.1.2 and increased version to 1.4.3

### DIFF
--- a/tests/base.robot
+++ b/tests/base.robot
@@ -9,7 +9,7 @@ Keyword Tags    base
 
 SDK version shall match the container version
     [Tags]    fast
-    Sdk Version    v1.4.2
+    Sdk Version    v1.4.3
 
 SDK user shall be ebcl
     [Tags]    fast


### PR DESCRIPTION
# Changes

- Integrate embdgen v0.1.2.
- Update container version to v1.4.3

# Dependencies:

none

# Tests results

```bash
(.venv) tom@del01171:~/ebcl/work2/ebcl_dev_container/tests$ ./run_tests 
Current directory: /home/tom/ebcl/work2/ebcl_dev_container/tests
Requirement already satisfied: docker==7.1.0 in /home/tom/ebcl/work2/ebcl_dev_container/.venv/lib/python3.10/site-packages (from -r /home/tom/ebcl/work2/ebcl_dev_container/requirements.txt (line 1)) (7.1.0)
Requirement already satisfied: PyYAML==6.0.2 in /home/tom/ebcl/work2/ebcl_dev_container/.venv/lib/python3.10/site-packages (from -r /home/tom/ebcl/work2/ebcl_dev_container/requirements.txt (line 2)) (6.0.2)
Requirement already satisfied: robotframework==7.1 in /home/tom/ebcl/work2/ebcl_dev_container/.venv/lib/python3.10/site-packages (from -r /home/tom/ebcl/work2/ebcl_dev_container/requirements.txt (line 3)) (7.1)
Requirement already satisfied: types-PyYAML==6.0.12.20240917 in /home/tom/ebcl/work2/ebcl_dev_container/.venv/lib/python3.10/site-packages (from -r /home/tom/ebcl/work2/ebcl_dev_container/requirements.txt (line 4)) (6.0.12.20240917)
Requirement already satisfied: requests>=2.26.0 in /home/tom/ebcl/work2/ebcl_dev_container/.venv/lib/python3.10/site-packages (from docker==7.1.0->-r /home/tom/ebcl/work2/ebcl_dev_container/requirements.txt (line 1)) (2.32.3)
Requirement already satisfied: urllib3>=1.26.0 in /home/tom/ebcl/work2/ebcl_dev_container/.venv/lib/python3.10/site-packages (from docker==7.1.0->-r /home/tom/ebcl/work2/ebcl_dev_container/requirements.txt (line 1)) (2.2.3)
Requirement already satisfied: idna<4,>=2.5 in /home/tom/ebcl/work2/ebcl_dev_container/.venv/lib/python3.10/site-packages (from requests>=2.26.0->docker==7.1.0->-r /home/tom/ebcl/work2/ebcl_dev_container/requirements.txt (line 1)) (3.10)
Requirement already satisfied: certifi>=2017.4.17 in /home/tom/ebcl/work2/ebcl_dev_container/.venv/lib/python3.10/site-packages (from requests>=2.26.0->docker==7.1.0->-r /home/tom/ebcl/work2/ebcl_dev_container/requirements.txt (line 1)) (2024.8.30)
Requirement already satisfied: charset-normalizer<4,>=2 in /home/tom/ebcl/work2/ebcl_dev_container/.venv/lib/python3.10/site-packages (from requests>=2.26.0->docker==7.1.0->-r /home/tom/ebcl/work2/ebcl_dev_container/requirements.txt (line 1)) (3.4.0)
Running the tests for dev container v1.4.3...
==============================================================================
Base & Build & Kiwi & Rust                                                    
==============================================================================
Base & Build & Kiwi & Rust.Base                                               
==============================================================================
RUNNER: docker
Using images from /home/tom/ebcl/work2/ebcl_dev_container/usage/images.
Using /home/tom/ebcl/work2/ebcl_dev_container/usage/results as result folder.
Using workspace from /home/tom/ebcl/work2/ebcl_dev_container/usage.
Dev container image ghcr.io/elektrobit/ebcl_dev_container:v1.4.3 is available.
CONTAINER_NAME: ebcl_dev_container
Stopping and deleting the container...
Running the container as background process...
SDK version shall match the container version                         | PASS |
------------------------------------------------------------------------------
SDK user shall be ebcl                                                | PASS |
------------------------------------------------------------------------------
SDK shall provide a proper Debian environment                         | PASS |
------------------------------------------------------------------------------
RUNNER: docker
Error response from daemon: cannot kill container: ebcl_dev_container: container 39a455271fd20c210068795b907520c720d40892764a1a47fda2a5fc9c3117ee is not running
Base & Build & Kiwi & Rust.Base                                       | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
Base & Build & Kiwi & Rust.Build                                              
==============================================================================
Containers shall build                                                Current directory: /home/tom/ebcl/work2/ebcl_dev_container/builder
Requirement already satisfied: docker==7.1.0 in /home/tom/ebcl/work2/ebcl_dev_container/.venv/lib/python3.10/site-packages (from -r /home/tom/ebcl/work2/ebcl_dev_container/requirements.txt (line 1)) (7.1.0)
Requirement already satisfied: PyYAML==6.0.2 in /home/tom/ebcl/work2/ebcl_dev_container/.venv/lib/python3.10/site-packages (from -r /home/tom/ebcl/work2/ebcl_dev_container/requirements.txt (line 2)) (6.0.2)
Requirement already satisfied: robotframework==7.1 in /home/tom/ebcl/work2/ebcl_dev_container/.venv/lib/python3.10/site-packages (from -r /home/tom/ebcl/work2/ebcl_dev_container/requirements.txt (line 3)) (7.1)
Requirement already satisfied: types-PyYAML==6.0.12.20240917 in /home/tom/ebcl/work2/ebcl_dev_container/.venv/lib/python3.10/site-packages (from -r /home/tom/ebcl/work2/ebcl_dev_container/requirements.txt (line 4)) (6.0.12.20240917)
Requirement already satisfied: requests>=2.26.0 in /home/tom/ebcl/work2/ebcl_dev_container/.venv/lib/python3.10/site-packages (from docker==7.1.0->-r /home/tom/ebcl/work2/ebcl_dev_container/requirements.txt (line 1)) (2.32.3)
Requirement already satisfied: urllib3>=1.26.0 in /home/tom/ebcl/work2/ebcl_dev_container/.venv/lib/python3.10/site-packages (from docker==7.1.0->-r /home/tom/ebcl/work2/ebcl_dev_container/requirements.txt (line 1)) (2.2.3)
Requirement already satisfied: certifi>=2017.4.17 in /home/tom/ebcl/work2/ebcl_dev_container/.venv/lib/python3.10/site-packages (from requests>=2.26.0->docker==7.1.0->-r /home/tom/ebcl/work2/ebcl_dev_container/requirements.txt (line 1)) (2024.8.30)
Requirement already satisfied: idna<4,>=2.5 in /home/tom/ebcl/work2/ebcl_dev_container/.venv/lib/python3.10/site-packages (from requests>=2.26.0->docker==7.1.0->-r /home/tom/ebcl/work2/ebcl_dev_container/requirements.txt (line 1)) (3.10)
Requirement already satisfied: charset-normalizer<4,>=2 in /home/tom/ebcl/work2/ebcl_dev_container/.venv/lib/python3.10/site-packages (from requests>=2.26.0->docker==7.1.0->-r /home/tom/ebcl/work2/ebcl_dev_container/requirements.txt (line 1)) (3.4.0)
Building EBcL SDK dev container...
INFO:root:Conifg: {'Base-Name': 'ebcl_dev_container', 'Repository': 'ghcr.io/elektrobit', 'Base-Container': 'ubuntu:22.04', 'Version': 'v1.4.3', 'Layers': ['../layers/base', '../layers/pbuilder', '../layers/rust', '../layers/kiwi', '../layers/appdev', '../layers/embdgen', '../layers/vscode', '../layers/squash']}
INFO:root:Builder: docker
INFO:root:Building layer ghcr.io/elektrobit/ebcl_dev_container_base:v1.4.3.
[+] Building 0.3s (38/38) FINISHED                                                                                                                                                                        docker:default
 => [internal] load build definition from Dockerfile.tmp                                                                                                                                                            0.0s
 => => transferring dockerfile: 3.44kB                                                                                                                                                                              0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)                                                                                                                                      0.0s
 => [internal] load metadata for docker.io/library/ubuntu:22.04                                                                                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                                                                                   0.0s
 => => transferring context: 2B                                                                                                                                                                                     0.0s
 => [internal] load build context                                                                                                                                                                                   0.0s
 => => transferring context: 803B                                                                                                                                                                                   0.0s
 => [ 1/33] FROM docker.io/library/ubuntu:22.04                                                                                                                                                                     0.0s
 => CACHED [ 2/33] RUN rm -rf /etc/apt/sources.list                                                                                                                                                                 0.0s
 => CACHED [ 3/33] COPY conf/apt/sources.list /etc/apt/sources.list                                                                                                                                                 0.0s
 => CACHED [ 4/33] RUN mkdir -p /etc/apt/trusted.gpg.d                                                                                                                                                              0.0s
 => CACHED [ 5/33] COPY conf/apt-keys/elektrobit.gpg /etc/apt/trusted.gpg.d/                                                                                                                                        0.0s
 => CACHED [ 6/33] RUN mkdir -p /etc/apt/sources.list.d                                                                                                                                                             0.0s
 => CACHED [ 7/33] COPY conf/apt/elektrobit.list /etc/apt/sources.list.d/                                                                                                                                           0.0s
 => CACHED [ 8/33] RUN dpkg --add-architecture arm64                                                                                                                                                                0.0s
 => CACHED [ 9/33] RUN apt update                                                                                                                                                                                   0.0s
 => CACHED [10/33] RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y     build-essential gcc g++ cmake pkg-config gdb-multiarch     gcc-aarch64-linux-gnu g++-aarch64-linux-gnu crossbuild-essential-ar  0.0s
 => CACHED [11/33] RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/bin                                                                                                                 0.0s
 => CACHED [12/33] RUN add-apt-repository ppa:elos-team/ppa                                                                                                                                                         0.0s
 => CACHED [13/33] RUN apt update                                                                                                                                                                                   0.0s
 => CACHED [14/33] RUN export LC_ALL=en_US.UTF-8 &&     export LANG=en_US.UTF-8 &&     locale-gen en_US.UTF-8                                                                                                       0.0s
 => CACHED [15/33] RUN userdel ubuntu || true                                                                                                                                                                       0.0s
 => CACHED [16/33] RUN addgroup --gid 1000 ebcl &&   useradd -rm -d /home/ebcl -s /bin/bash -g ebcl -G sudo -u 1000 ebcl &&   echo "ebcl ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers &&   mkdir -p /home/ebcl/.ssh  0.0s
 => CACHED [17/33] RUN mkdir -p /build/results/images &&     mkdir -p results/packages &&     mkdir -p images &&     mkdir -p identity &&     mkdir -p bin &&     chown -R ebcl:ebcl /build                         0.0s
 => CACHED [18/33] RUN mkdir -p /workspace &&     chown -R ebcl:ebcl /workspace                                                                                                                                     0.0s
 => CACHED [19/33] RUN mkdir -p /home/ebcl/.ssh &&     chown -R ebcl:ebcl /home/ebcl                                                                                                                                0.0s
 => CACHED [20/33] COPY conf/bash/bashrc /home/ebcl/.bashrc                                                                                                                                                         0.0s
 => CACHED [21/33] RUN chown -R ebcl:ebcl /home/ebcl &&     chmod +x /home/ebcl/.bashrc                                                                                                                             0.0s
 => CACHED [22/33] RUN mkdir -p /root                                                                                                                                                                               0.0s
 => CACHED [23/33] COPY conf/bash/bashrc /root/.bashrc                                                                                                                                                              0.0s
 => CACHED [24/33] RUN chown -R root:root /root &&     chmod +x /root/.bashrc                                                                                                                                       0.0s
 => CACHED [25/33] COPY scripts/bash/* /build/bin/                                                                                                                                                                  0.0s
 => CACHED [26/33] COPY scripts/gpg/* /build/bin/                                                                                                                                                                   0.0s
 => CACHED [27/33] COPY scripts/qemu/* /build/bin/                                                                                                                                                                  0.0s
 => CACHED [28/33] COPY scripts/mount/* /build/bin/                                                                                                                                                                 0.0s
 => CACHED [29/33] RUN chown -R ebcl:ebcl /build/bin &&     chmod +x /build/bin/*                                                                                                                                   0.0s
 => CACHED [30/33] RUN echo v1.4.3 > /etc/sdk_version                                                                                                                                                               0.0s
 => CACHED [31/33] RUN python3 -m venv /build/venv                                                                                                                                                                  0.0s
 => CACHED [32/33] RUN pip install mypy pep8 pylint pytest pytest-cov robotframework                                                                                                                                0.0s
 => CACHED [33/33] RUN chown -R ebcl:ebcl /build/venv                                                                                                                                                               0.0s
 => exporting to image                                                                                                                                                                                              0.0s
 => => exporting layers                                                                                                                                                                                             0.0s
 => => writing image sha256:dbc81ca400f1b732764d6de89aa883c23e11a5596f82c33e73ff3164880597bc                                                                                                                        0.0s
 => => naming to ghcr.io/elektrobit/ebcl_dev_container_base:v1.4.3                                                                                                                                                  0.0s

 1 warning found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
INFO:root:Building layer ghcr.io/elektrobit/ebcl_dev_container_pbuilder:v1.4.3.
[+] Building 0.3s (18/18) FINISHED                                                                                                                                                                        docker:default
 => [internal] load build definition from Dockerfile.tmp                                                                                                                                                            0.0s
 => => transferring dockerfile: 1.36kB                                                                                                                                                                              0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)                                                                                                                                      0.0s
 => [internal] load metadata for ghcr.io/elektrobit/ebcl_dev_container_base:v1.4.3                                                                                                                                  0.0s
 => [internal] load .dockerignore                                                                                                                                                                                   0.0s
 => => transferring context: 2B                                                                                                                                                                                     0.0s
 => [internal] load build context                                                                                                                                                                                   0.0s
 => => transferring context: 552B                                                                                                                                                                                   0.0s
 => [ 1/13] FROM ghcr.io/elektrobit/ebcl_dev_container_base:v1.4.3                                                                                                                                                  0.0s
 => CACHED [ 2/13] RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y     dh-make devscripts pbuilder                                                                                                     0.0s
 => CACHED [ 3/13] COPY conf/pbuilder/pbuilderrc /home/ebcl/.pbuilderrc                                                                                                                                             0.0s
 => CACHED [ 4/13] RUN sudo chown ebcl:ebcl /home/ebcl/.pbuilderrc && chmod +x /home/ebcl/.pbuilderrc                                                                                                               0.0s
 => CACHED [ 5/13] RUN mkdir -p /home/ebcl/.pbuilder/hooks/                                                                                                                                                         0.0s
 => CACHED [ 6/13] COPY conf/pbuilder/G99apt_arch /home/ebcl/.pbuilder/hooks/G99apt_arch                                                                                                                            0.0s
 => CACHED [ 7/13] RUN sudo chown ebcl:ebcl /home/ebcl/.pbuilder/hooks/* && chmod +x /home/ebcl/.pbuilder/hooks/*                                                                                                   0.0s
 => CACHED [ 8/13] RUN sudo ln -s /home/ebcl/.pbuilderrc /root/.pbuilderrc                                                                                                                                          0.0s
 => CACHED [ 9/13] COPY scripts/deb/* /build/bin/                                                                                                                                                                   0.0s
 => CACHED [10/13] COPY scripts/pbuilder/* /build/bin/                                                                                                                                                              0.0s
 => CACHED [11/13] RUN chown -R ebcl:ebcl /build/bin &&     chmod +x /build/bin/*                                                                                                                                   0.0s
 => CACHED [12/13] RUN gpg --no-default-keyring --keyring trustedkeys.gpg --import /etc/apt/trusted.gpg.d/elektrobit.gpg                                                                                            0.0s
 => CACHED [13/13] RUN gpg --no-default-keyring --keyring trustedkeys.gpg --import /etc/apt/trusted.gpg.d/ubuntu-keyring-2018-archive.gpg                                                                           0.0s
 => exporting to image                                                                                                                                                                                              0.0s
 => => exporting layers                                                                                                                                                                                             0.0s
 => => writing image sha256:d0d05505d04cc9887f24bff66b5336aeaa4a8d99f0f01c76bbfbc1d90d0a5c78                                                                                                                        0.0s
 => => naming to ghcr.io/elektrobit/ebcl_dev_container_pbuilder:v1.4.3                                                                                                                                              0.0s

 1 warning found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
INFO:root:Building layer ghcr.io/elektrobit/ebcl_dev_container_rust:v1.4.3.
[+] Building 0.3s (8/8) FINISHED                                                                                                                                                                          docker:default
 => [internal] load build definition from Dockerfile.tmp                                                                                                                                                            0.0s
 => => transferring dockerfile: 516B                                                                                                                                                                                0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)                                                                                                                                      0.0s
 => [internal] load metadata for ghcr.io/elektrobit/ebcl_dev_container_pbuilder:v1.4.3                                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                                                                                   0.0s
 => => transferring context: 2B                                                                                                                                                                                     0.0s
 => [1/4] FROM ghcr.io/elektrobit/ebcl_dev_container_pbuilder:v1.4.3                                                                                                                                                0.0s
 => CACHED [2/4] RUN echo "export PATH=$PATH:~/.cargo/bin" >> /home/ebcl/.bashrc                                                                                                                                    0.0s
 => CACHED [3/4] RUN echo "export PATH=$PATH:/home/ebcl/.cargo/bin" >> /root/.bashrc                                                                                                                                0.0s
 => CACHED [4/4] RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y                                                                                                                        0.0s
 => exporting to image                                                                                                                                                                                              0.0s
 => => exporting layers                                                                                                                                                                                             0.0s
 => => writing image sha256:73f86089f7cf86b76323bc607959d15159729e41f5d2738c0f2d4c9b0add9bd9                                                                                                                        0.0s
 => => naming to ghcr.io/elektrobit/ebcl_dev_container_rust:v1.4.3                                                                                                                                                  0.0s

 1 warning found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
INFO:root:Building layer ghcr.io/elektrobit/ebcl_dev_container_kiwi:v1.4.3.
[+] Building 0.3s (20/20) FINISHED                                                                                                                                                                        docker:default
 => [internal] load build definition from Dockerfile.tmp                                                                                                                                                            0.0s
 => => transferring dockerfile: 1.11kB                                                                                                                                                                              0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)                                                                                                                                      0.0s
 => [internal] load metadata for ghcr.io/elektrobit/ebcl_dev_container_rust:v1.4.3                                                                                                                                  0.0s
 => [internal] load .dockerignore                                                                                                                                                                                   0.0s
 => => transferring context: 2B                                                                                                                                                                                     0.0s
 => [internal] load build context                                                                                                                                                                                   0.0s
 => => transferring context: 987B                                                                                                                                                                                   0.0s
 => [ 1/15] FROM ghcr.io/elektrobit/ebcl_dev_container_rust:v1.4.3                                                                                                                                                  0.0s
 => CACHED [ 2/15] RUN mkdir -p /etc/berrymill                                                                                                                                                                      0.0s
 => CACHED [ 3/15] COPY conf/berrymill/berrymill_local.conf /etc/berrymill                                                                                                                                          0.0s
 => CACHED [ 4/15] COPY conf/berrymill/berrymill.conf /etc/berrymill                                                                                                                                                0.0s
 => CACHED [ 5/15] COPY conf/kiwi/kiwi-boxed-plugin.yml /etc/berrymill                                                                                                                                              0.0s
 => CACHED [ 6/15] COPY conf/kiwi/kiwi.yml /etc                                                                                                                                                                     0.0s
 => CACHED [ 7/15] RUN mkdir -p /etc/berrymill/keyrings.d                                                                                                                                                           0.0s
 => CACHED [ 8/15] RUN cp /etc/apt/trusted.gpg.d/elektrobit.gpg /etc/berrymill/keyrings.d/                                                                                                                          0.0s
 => CACHED [ 9/15] WORKDIR /build                                                                                                                                                                                   0.0s
 => CACHED [10/15] RUN pip install kiwi==10.1.2 kiwi-boxed-plugin==0.2.36                                                                                                                                           0.0s
 => CACHED [11/15] RUN pip install 'berrymill @ git+https://github.com/tomirgang/berrymill.git@59dbfd7d022681402ef5d4758e4e146411f1cad6'                                                                            0.0s
 => CACHED [12/15] COPY scripts/apt/* /build/bin/                                                                                                                                                                   0.0s
 => CACHED [13/15] COPY scripts/berrymill/* /build/bin/                                                                                                                                                             0.0s
 => CACHED [14/15] COPY scripts/gpg/* /build/bin/                                                                                                                                                                   0.0s
 => CACHED [15/15] COPY scripts/kiwi/* /build/bin/                                                                                                                                                                  0.0s
 => exporting to image                                                                                                                                                                                              0.0s
 => => exporting layers                                                                                                                                                                                             0.0s
 => => writing image sha256:b45edef296d8697238a9befc39c8aa71ede19c8b5c2edbc60c5204ae22d0be35                                                                                                                        0.0s
 => => naming to ghcr.io/elektrobit/ebcl_dev_container_kiwi:v1.4.3                                                                                                                                                  0.0s

 1 warning found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
INFO:root:Building layer ghcr.io/elektrobit/ebcl_dev_container_appdev:v1.4.3.
[+] Building 0.3s (15/15) FINISHED                                                                                                                                                                        docker:default
 => [internal] load build definition from Dockerfile.tmp                                                                                                                                                            0.0s
 => => transferring dockerfile: 944B                                                                                                                                                                                0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)                                                                                                                                      0.0s
 => WARN: LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 8)                                                                                                    0.0s
 => [internal] load metadata for ghcr.io/elektrobit/ebcl_dev_container_kiwi:v1.4.3                                                                                                                                  0.0s
 => [internal] load .dockerignore                                                                                                                                                                                   0.0s
 => => transferring context: 2B                                                                                                                                                                                     0.0s
 => [ 1/10] FROM ghcr.io/elektrobit/ebcl_dev_container_kiwi:v1.4.3                                                                                                                                                  0.0s
 => [internal] load build context                                                                                                                                                                                   0.0s
 => => transferring context: 363B                                                                                                                                                                                   0.0s
 => CACHED [ 2/10] RUN apt -y install libjsoncpp-dev                                                                                                                                                                0.0s
 => CACHED [ 3/10] RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null                             0.0s
 => CACHED [ 4/10] RUN echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null                      0.0s
 => CACHED [ 5/10] RUN apt-get update && apt -y install cmake sshpass rsync                                                                                                                                         0.0s
 => CACHED [ 6/10] WORKDIR /build                                                                                                                                                                                   0.0s
 => CACHED [ 7/10] RUN mkdir -p /build/cmake                                                                                                                                                                        0.0s
 => CACHED [ 8/10] COPY conf/cmake/* /build/cmake/                                                                                                                                                                  0.0s
 => CACHED [ 9/10] COPY scripts/cmake/* /build/bin/                                                                                                                                                                 0.0s
 => CACHED [10/10] RUN mkdir -p /build/results/apps                                                                                                                                                                 0.0s
 => exporting to image                                                                                                                                                                                              0.0s
 => => exporting layers                                                                                                                                                                                             0.0s
 => => writing image sha256:38a3e45c4aebf9b6328dcad227e5e5f47270db674f82294b589f71fdee30740e                                                                                                                        0.0s
 => => naming to ghcr.io/elektrobit/ebcl_dev_container_appdev:v1.4.3                                                                                                                                                0.0s

 2 warnings found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 8)
INFO:root:Building layer ghcr.io/elektrobit/ebcl_dev_container_embdgen:v1.4.3.
[+] Building 0.3s (22/22) FINISHED                                                                                                                                                                        docker:default
 => [internal] load build definition from Dockerfile.tmp                                                                                                                                                            0.0s
 => => transferring dockerfile: 1.30kB                                                                                                                                                                              0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)                                                                                                                                      0.0s
 => WARN: LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 12)                                                                                                   0.0s
 => [internal] load metadata for ghcr.io/elektrobit/ebcl_dev_container_appdev:v1.4.3                                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                                                                                   0.0s
 => => transferring context: 2B                                                                                                                                                                                     0.0s
 => [internal] load build context                                                                                                                                                                                   0.0s
 => => transferring context: 65B                                                                                                                                                                                    0.0s
 => [ 1/17] FROM ghcr.io/elektrobit/ebcl_dev_container_appdev:v1.4.3                                                                                                                                                0.0s
 => CACHED [ 2/17] RUN apt -y install     python3 python3-pip python3-venv libparted-dev python3-dev pkg-config     mtools e2fsprogs cryptsetup-bin dosfstools fakeroot fdisk udev cpio                             0.0s
 => CACHED [ 3/17] RUN pip install pyyaml types-PyYAML     requests types-requests     Jinja2 types-Jinja2     unix-ar zstandard                                                                                    0.0s
 => CACHED [ 4/17] WORKDIR /build                                                                                                                                                                                   0.0s
 => CACHED [ 5/17] RUN git clone --branch v0.1.2 https://github.com/Elektrobit/embdgen.git embdgen                                                                                                                  0.0s
 => CACHED [ 6/17] WORKDIR /build/embdgen                                                                                                                                                                           0.0s
 => CACHED [ 7/17] RUN pip install -e embdgen-core                                                                                                                                                                  0.0s
 => CACHED [ 8/17] RUN pip install -e embdgen-cominit                                                                                                                                                               0.0s
 => CACHED [ 9/17] RUN pip install -e embdgen-config-yaml                                                                                                                                                           0.0s
 => CACHED [10/17] RUN mkdir -p /build/keys                                                                                                                                                                         0.0s
 => CACHED [11/17] COPY conf/elektrobit.pub /build/keys/                                                                                                                                                            0.0s
 => CACHED [12/17] RUN pip install jsonpickle robotframework requests pyyaml psutil                                                                                                                                 0.0s
 => CACHED [13/17] WORKDIR /build                                                                                                                                                                                   0.0s
 => CACHED [14/17] RUN git clone --branch v1.3.2 https://github.com/Elektrobit/ebcl_build_tools ebcl_build_tools                                                                                                    0.0s
 => CACHED [15/17] RUN pip install -e ebcl_build_tools                                                                                                                                                              0.0s
 => CACHED [16/17] RUN mkdir -p /workspace/state/cache                                                                                                                                                              0.0s
 => CACHED [17/17] RUN mkdir -p /workspace/state/apt                                                                                                                                                                0.0s
 => exporting to image                                                                                                                                                                                              0.0s
 => => exporting layers                                                                                                                                                                                             0.0s
 => => writing image sha256:a48dd5e2af23abfd4a582302a69c1d89ad19844538123a0659da7594072c0610                                                                                                                        0.0s
 => => naming to ghcr.io/elektrobit/ebcl_dev_container_embdgen:v1.4.3                                                                                                                                               0.0s

 2 warnings found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 12)
INFO:root:Building layer ghcr.io/elektrobit/ebcl_dev_container_vscode:v1.4.3.
[+] Building 0.3s (9/9) FINISHED                                                                                                                                                                          docker:default
 => [internal] load build definition from Dockerfile.tmp                                                                                                                                                            0.0s
 => => transferring dockerfile: 482B                                                                                                                                                                                0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)                                                                                                                                      0.0s
 => [internal] load metadata for ghcr.io/elektrobit/ebcl_dev_container_embdgen:v1.4.3                                                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                                                                                   0.0s
 => => transferring context: 2B                                                                                                                                                                                     0.0s
 => [1/5] FROM ghcr.io/elektrobit/ebcl_dev_container_embdgen:v1.4.3                                                                                                                                                 0.0s
 => CACHED [2/5] WORKDIR /build                                                                                                                                                                                     0.0s
 => CACHED [3/5] RUN git clone --branch v1.0.2 https://github.com/Elektrobit/ebcl_vscode_tools.git ebcl_vscode_tools                                                                                                0.0s
 => CACHED [4/5] RUN pip install -e ebcl_vscode_tools                                                                                                                                                               0.0s
 => CACHED [5/5] RUN pip install libtmux                                                                                                                                                                            0.0s
 => exporting to image                                                                                                                                                                                              0.0s
 => => exporting layers                                                                                                                                                                                             0.0s
 => => writing image sha256:4d6d081c72e3ab6e83f23420e1936b7120828e6125666d34fcc2d26731cf736f                                                                                                                        0.0s
 => => naming to ghcr.io/elektrobit/ebcl_dev_container_vscode:v1.4.3                                                                                                                                                0.0s

 1 warning found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
INFO:root:Building layer ghcr.io/elektrobit/ebcl_dev_container_squash:v1.4.3.
[+] Building 0.3s (6/6) FINISHED                                                                                                                                                                          docker:default
 => [internal] load build definition from Dockerfile.tmp                                                                                                                                                            0.0s
 => => transferring dockerfile: 173B                                                                                                                                                                                0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)                                                                                                                                      0.0s
 => [internal] load metadata for ghcr.io/elektrobit/ebcl_dev_container_vscode:v1.4.3                                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                                                                                   0.0s
 => => transferring context: 2B                                                                                                                                                                                     0.0s
 => [base_container_name 1/1] FROM ghcr.io/elektrobit/ebcl_dev_container_vscode:v1.4.3                                                                                                                              0.0s
 => CACHED [stage-1 1/1] COPY --from=base_container_name / /                                                                                                                                                        0.0s
 => exporting to image                                                                                                                                                                                              0.0s
 => => exporting layers                                                                                                                                                                                             0.0s
 => => writing image sha256:18daf008aea9f3c0e5dc719bf2d3c76ff858db4f133da35791a26faa9d901174                                                                                                                        0.0s
 => => naming to ghcr.io/elektrobit/ebcl_dev_container_squash:v1.4.3                                                                                                                                                0.0s

 1 warning found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
INFO:root:Tagging container ghcr.io/elektrobit/ebcl_dev_container_squash:v1.4.3 as ghcr.io/elektrobit/ebcl_dev_container:v1.4.3.
Containers shall build                                                | PASS |
------------------------------------------------------------------------------
Base & Build & Kiwi & Rust.Build                                      | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Base & Build & Kiwi & Rust.Kiwi                                               
==============================================================================
RUNNER: docker
Using images from /home/tom/ebcl/work2/ebcl_dev_container/usage/images.
Using /home/tom/ebcl/work2/ebcl_dev_container/usage/results as result folder.
Using workspace from /home/tom/ebcl/work2/ebcl_dev_container/usage.
Dev container image ghcr.io/elektrobit/ebcl_dev_container:v1.4.3 is available.
CONTAINER_NAME: ebcl_dev_container
Stopping and deleting the container...
Running the container as background process...
SDK shall provide Kiwi-ng and Berrymill                               | PASS |
------------------------------------------------------------------------------
RUNNER: docker
Error response from daemon: cannot kill container: ebcl_dev_container: container 647d4dd7de0e3174ac9d850575a94ea8b7f496c2827f4fc48dc2c59ec18ec111 is not running
Base & Build & Kiwi & Rust.Kiwi                                       | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Base & Build & Kiwi & Rust.Rust                                               
==============================================================================
RUNNER: docker
Using images from /home/tom/ebcl/work2/ebcl_dev_container/usage/images.
Using /home/tom/ebcl/work2/ebcl_dev_container/usage/results as result folder.
Using workspace from /home/tom/ebcl/work2/ebcl_dev_container/usage.
Dev container image ghcr.io/elektrobit/ebcl_dev_container:v1.4.3 is available.
CONTAINER_NAME: ebcl_dev_container
Stopping and deleting the container...
Running the container as background process...
SDK shall provide rustc                                               | PASS |
------------------------------------------------------------------------------
SDK shall provide cargo                                               | PASS |
------------------------------------------------------------------------------
RUNNER: docker
Error response from daemon: cannot kill container: ebcl_dev_container: container ada001a0bd62f5ea13bbe6e1f495bc1a1b19b8dd1f972462b5da8d017c1ebbae is not running
Base & Build & Kiwi & Rust.Rust                                       | PASS |
2 tests, 2 passed, 0 failed
==============================================================================
Base & Build & Kiwi & Rust                                            | PASS |
7 tests, 7 passed, 0 failed
==============================================================================
Output:  /home/tom/ebcl/work2/ebcl_dev_container/tests/output.xml
Log:     /home/tom/ebcl/work2/ebcl_dev_container/tests/log.html
Report:  /home/tom/ebcl/work2/ebcl_dev_container/tests/report.html
```
# Developer Checklist:

- [x] Test: Changes are tested
- N/A Doc: Documentation has been updated 
- [x] Git: Informative git commit message(s)
- N/A Issue: If a related GitHub issue exists, linking is done

## Checklists for documentation
- N/A Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- N/A Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- N/A Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- N/A Terminology: technical terms are clear and they are used correctly and documented in the glossary
- N/A Level of detail: the content matches the detail level necessary for the reviewed object
      
# Reviewer checklist:
- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer
      
## Checklists for documentation
- [ ] Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- [ ] Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- [ ] Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- [ ] Terminology: technical terms are clear and they are used correctly and documented in the glossary
- [ ] Level of detail: the content matches the detail level necessary for the reviewed object
