### PR TITLE
Add packages for kernel configuration and building

### DIFF
--- a/configuration/build_config.yaml
+++ b/configuration/build_config.yaml
@@ -11,4 +11,5 @@ Layers:
   - ../layers/embdgen
   - ../layers/vscode
   - ../layers/ebclfsa
+  - ../layers/kernel
   - ../layers/squash

--- a/layers/kernel/Dockerfile
+++ b/layers/kernel/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update 
+ && apt-get install --no-install-recommends -y \
+    build-essential \
+    flex \
+    bison \
+    bc \
+    libssl-dev \
+    libncurses-dev \
+    rsync \
+    kmod \
+    cpio \
+    make
+

--- a/layers/kernel/Dockerfile
+++ b/layers/kernel/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update 
+RUN apt-get update \ 
  && apt-get install --no-install-recommends -y \
     build-essential \
     flex \

--- a/layers/kernel/README.md
+++ b/layers/kernel/README.md
@@ -1,0 +1,2 @@
+# EBcL SDK: Kernel build support
+Support layer for kernel configuration and building.


### PR DESCRIPTION

# Changes
This PR adds the required packages for kernel configuration and building


# Tests results
```bash
Current directory: /mnt/storage/ebcl-github/ebcl_dev_container/tests
Running the tests for dev container v1.4.5...
==============================================================================
Base & Build & Kiwi & Rust                                                    
==============================================================================
Base & Build & Kiwi & Rust.Base                                               
==============================================================================
RUNNER: docker
Using images from /mnt/storage/ebcl-github/ebcl_dev_container/usage/images.
Using /mnt/storage/ebcl-github/ebcl_dev_container/usage/results as result folder.
Using workspace from /mnt/storage/ebcl-github/ebcl_dev_container/usage.
Dev container image ghcr.io/elektrobit/ebcl_dev_container:v1.4.5 is available.
CONTAINER_NAME: ebcl_dev_container
Stopping and deleting the container...
Running the container as background process...
SDK version shall match the container version                         | PASS |
------------------------------------------------------------------------------
SDK user shall be ebcl                                                | PASS |
------------------------------------------------------------------------------
SDK shall provide a proper Debian environment                         | PASS |
------------------------------------------------------------------------------
RUNNER: docker
Error response from daemon: Cannot kill container: ebcl_dev_container: Container 79985a2f9c9320cb914ab7cebc70be9bb5ef9a31197229c20ffe75b468ecb532 is not running
Base & Build & Kiwi & Rust.Base                                       | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
Base & Build & Kiwi & Rust.Build                                              
==============================================================================
Containers shall build                                                Current directory: /mnt/storage/ebcl-github/ebcl_dev_container/builder
Building EBcL SDK dev container...
INFO:root:Conifg: {'Base-Name': 'ebcl_dev_container', 'Repository': 'ghcr.io/elektrobit', 'Base-Container': 'ubuntu:22.04', 'Version': 'v1.4.5', 'Layers': ['../layers/base', '../layers/pbuilder', '../layers/rust', '../layers/kiwi', '../layers/appdev', '../layers/embdgen', '../layers/vscode', '../layers/ebclfsa', '../layers/kernel', '../layers/squash']}
INFO:root:Builder: docker
INFO:root:Building layer ghcr.io/elektrobit/ebcl_dev_container_base:v1.4.5.
[+] Building 0.1s (38/38) FINISHED                                                                                                                                                                                                                                         
INFO:root:Tagging container ghcr.io/elektrobit/ebcl_dev_container_squash:v1.4.5 as ghcr.io/elektrobit/ebcl_dev_container:v1.4.5.
Containers shall build                                                | PASS |
------------------------------------------------------------------------------
Base & Build & Kiwi & Rust.Build                                      | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Base & Build & Kiwi & Rust.Kiwi                                               
==============================================================================
RUNNER: docker
Using images from /mnt/storage/ebcl-github/ebcl_dev_container/usage/images.
Using /mnt/storage/ebcl-github/ebcl_dev_container/usage/results as result folder.
Using workspace from /mnt/storage/ebcl-github/ebcl_dev_container/usage.
Dev container image ghcr.io/elektrobit/ebcl_dev_container:v1.4.5 is available.
CONTAINER_NAME: ebcl_dev_container
Stopping and deleting the container...
Running the container as background process...
SDK shall provide Kiwi-ng and Berrymill                               | PASS |
------------------------------------------------------------------------------
RUNNER: docker
Error response from daemon: Cannot kill container: ebcl_dev_container: Container 3fa2b391eca6475c1c829c0706e03692707d45712bd11002299cad3533dbbccb is not running
Base & Build & Kiwi & Rust.Kiwi                                       | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Base & Build & Kiwi & Rust.Rust                                               
==============================================================================
RUNNER: docker
Using images from /mnt/storage/ebcl-github/ebcl_dev_container/usage/images.
Using /mnt/storage/ebcl-github/ebcl_dev_container/usage/results as result folder.
Using workspace from /mnt/storage/ebcl-github/ebcl_dev_container/usage.
Dev container image ghcr.io/elektrobit/ebcl_dev_container:v1.4.5 is available.
CONTAINER_NAME: ebcl_dev_container
Stopping and deleting the container...
Running the container as background process...
SDK shall provide rustc                                               | PASS |
------------------------------------------------------------------------------
SDK shall provide cargo                                               | PASS |
------------------------------------------------------------------------------
RUNNER: docker
Error response from daemon: Cannot kill container: ebcl_dev_container: Container 7b31408ad37106e8a94bebc0dac736be6bee5c89dfacbae4e0c9294decd6fcdd is not running
Base & Build & Kiwi & Rust.Rust                                       | PASS |
2 tests, 2 passed, 0 failed
==============================================================================
Base & Build & Kiwi & Rust                                            | PASS |
7 tests, 7 passed, 0 failed
==============================================================================
Output:  /mnt/storage/ebcl-github/ebcl_dev_container/tests/output.xml
Log:     /mnt/storage/ebcl-github/ebcl_dev_container/tests/log.html
Report:  /mnt/storage/ebcl-github/ebcl_dev_container/tests/report.html

```
# Developer Checklist:
- [ ] Test: Changes are tested
- [ ] Doc: Documentation has been updated 
- [ ] Git: Informative git commit message(s)
- [ ] Issue: If a related GitHub issue exists, linking is done

## Checklists for documentation
- [ ] Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- [ ] Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- [ ] Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- [ ] Terminology: technical terms are clear and they are used correctly and documented in the glossary
- [ ] Level of detail: the content matches the detail level necessary for the reviewed object
      
# Reviewer checklist:
- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer
      
## Checklists for documentation
- [ ] Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- [ ] Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- [ ] Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- [ ] Terminology: technical terms are clear and they are used correctly and documented in the glossary
- [ ] Level of detail: the content matches the detail level necessary for the reviewed object
