### PR TITLE
Build tools v1.3.6

### DIFF
--- a/configuration/build_config.yaml
+++ b/configuration/build_config.yaml
@@ -1,7 +1,7 @@
 Base-Name: ebcl_dev_container
 Repository: ghcr.io/elektrobit
 Base-Container: ubuntu:22.04
-Version: v1.4.6
+Version: v1.4.7
 Layers:
   - ../layers/base
   - ../layers/pbuilder

--- a/layers/embdgen/Dockerfile
+++ b/layers/embdgen/Dockerfile
@@ -21,6 +21,8 @@ RUN pip install pyyaml types-PyYAML \
     Jinja2 types-Jinja2 \
     unix-ar zstandard
 
+USER $CONTAINER_USER
+
 # Install embedgen
 WORKDIR /build
 RUN git clone --branch v0.1.2 https://github.com/Elektrobit/embdgen.git embdgen
@@ -38,9 +40,12 @@ RUN pip install jsonpickle robotframework requests pyyaml psutil
 
 # Install EBcl build tools
 WORKDIR /build
-RUN git clone --branch v1.3.5 https://github.com/Elektrobit/ebcl_build_tools ebcl_build_tools
+RUN git clone --branch v1.3.6 https://github.com/Elektrobit/ebcl_build_tools ebcl_build_tools
 RUN pip install -e ebcl_build_tools
 
 # Prepare cache folders
 RUN mkdir -p /workspace/state/cache
 RUN mkdir -p /workspace/state/apt
+RUN mkdir -p /workspace/state/debootstrap
+
+USER root

--- a/tests/base.robot
+++ b/tests/base.robot
@@ -9,7 +9,7 @@ Keyword Tags    base
 
 SDK version shall match the container version
     [Tags]    fast
-    Sdk Version    v1.4.6
+    Sdk Version    v1.4.7
 
 SDK user shall be ebcl
     [Tags]    fast


### PR DESCRIPTION
# Changes

- Update build tools to v1.3.6
- Fix ownership of venv, build tools and embdgen.

# Dependencies:

none

# Tests results

```bash
SDK shall provide rustc                                               | PASS |
------------------------------------------------------------------------------
SDK shall provide cargo                                               | PASS |
------------------------------------------------------------------------------
RUNNER: docker
Error response from daemon: cannot kill container: ebcl_dev_container: container 34d47205009c6cc8343729a8895dc39ccad324371f4dcb7a4b27cfd6c59cd299 is not running
Base & Build & Kiwi & Rust.Rust                                       | PASS |
2 tests, 2 passed, 0 failed
==============================================================================
Base & Build & Kiwi & Rust                                            | PASS |
7 tests, 7 passed, 0 failed
==============================================================================
```

# Developer Checklist:

- [x] Test: Changes are tested
- N/A Doc: Documentation has been updated 
- [x] Git: Informative git commit message(s)
- N/A Issue: If a related GitHub issue exists, linking is done

# Reviewer checklist:

- [x] Review: Changes are reviewed
- [x] Review: Tested by the reviewer
