### PR TITLE
tests: take expected sdk version from config file

### DIFF
--- a/tests/base.robot
+++ b/tests/base.robot
@@ -9,7 +9,7 @@ Keyword Tags    base
 
 SDK version shall match the container version
     [Tags]    fast
-    Sdk Version    v1.4.7
+    Sdk Version    ${CONTAINER_VERSION}
 
 SDK user shall be ebcl
     [Tags]    fast

--- a/tests/run_tests
+++ b/tests/run_tests
@@ -22,4 +22,4 @@ pip install -r ${GIT_ROOT}/requirements.txt
 
 echo "Running the tests for dev container ${VERSION}..."
 
-robot -L TRACE *.robot
+robot -v CONTAINER_VERSION:${VERSION} -L TRACE *.robot


### PR DESCRIPTION
Updating the version in two places on every dump is cumbersome and was forgotten in the past at least twice.
There is no good reason to not take the expected version from the config file.