### PR TITLE
Clang compliler support

### DIFF
--- a/layers/ebclfsa/Dockerfile
+++ b/layers/ebclfsa/Dockerfile
@@ -1,13 +1,20 @@
 FROM ubuntu:latest
 
 ARG CONTAINER_USER="ebcl"
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TZ=Etc/UTC
 
 USER root
 
 COPY conf/apt/ebclfsa.list /etc/apt/sources.list.d/
 # Install ebclfsa tools
-RUN apt-get update && apt-get install -y musl-dev:arm64 lisa-elf-enabler
-
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    clang \
+    lisa-elf-enabler \
+    lld \
+    llvm \
+    musl-dev:arm64
+    
 # add cmake toolchains
 RUN mkdir -p /build/cmake
 COPY conf/cmake/* /build/cmake/

--- a/layers/ebclfsa/conf/cmake/ebclfsaPresets.json
+++ b/layers/ebclfsa/conf/cmake/ebclfsaPresets.json
@@ -14,8 +14,7 @@
             "hidden": true,
             "toolchainFile": "/build/cmake/toolchain-ebclfsa-aarch64.cmake",
             "environment": {
-                "BUILDDIR": "/build/results/apps/$env{APP_NAME}/${presetName}/build",
-                "REALGCC": "aarch64-linux-gnu-gcc"
+                "BUILDDIR": "/build/results/apps/$env{APP_NAME}/${presetName}/build"
             }
         }
     ]

--- a/layers/ebclfsa/conf/cmake/toolchain-ebclfsa-aarch64.cmake
+++ b/layers/ebclfsa/conf/cmake/toolchain-ebclfsa-aarch64.cmake
@@ -1,13 +1,18 @@
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR aarch64)
 
-set(CMAKE_C_COMPILER aarch64-linux-musl-gcc)
-set(CMAKE_CXX_COMPILER aarch64-linux-musl-g++)
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CXX_COMPILER clang++)
 
 set(CMAKE_SYSROOT /build/sysroot_hi_aarch64)
 
 # Only static binaries are allowed
-set(CMAKE_C_FLAGS -static)
+set(CMAKE_C_FLAGS "-static")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -isystem /usr/include/aarch64-linux-musl/ -isystem /usr/lib/gcc-cross/aarch64-linux-gnu/11/include/")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -target aarch64-linux-musl")
+
+set(CMAKE_EXE_LINKER_FLAGS "-fuse-ld=lld -nostdlib -L/usr/lib/aarch64-linux-musl -L/usr/lib/gcc-cross/aarch64-linux-gnu/11 -lc -lgcc")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /usr/lib/aarch64-linux-musl/crt1.o /usr/lib/aarch64-linux-musl/crti.o /usr/lib/aarch64-linux-musl/crtn.o /usr/lib/gcc-cross/aarch64-linux-gnu/11/crtend.o /usr/lib/gcc-cross/aarch64-linux-gnu/11/crtbeginT.o")
 
 set(CMAKE_FIND_ROOT_PATH "${CMAKE_SYSROOT}")
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)


### PR DESCRIPTION
 ebclfsa-layer: Add Clang/LLVM as an alternative compiler for hi-apps

Update the Dockerfile to include Clang, LLVM, and LLD as alternative toolchain components for building high-integrity applications.


ebclfsa-layer: update CMake config files

Edited the CMake JSON configuration files to replace the default GCC-based build system with the:
      Clang as the compiler
      LLD as the linker
      musl as the standard C library