### PR TITLE
Yocto support

### DIFF
--- a/configuration/build_config.yaml
+++ b/configuration/build_config.yaml
@@ -5,7 +5,6 @@ Version: v1.4.10
 Layers:
   - ../layers/base
   - ../layers/pbuilder
-  - ../layers/rust
   - ../layers/kiwi
   - ../layers/appdev
   - ../layers/build_tools

--- a/configuration/build_config.yaml
+++ b/configuration/build_config.yaml
@@ -1,7 +1,7 @@
 Base-Name: ebcl_dev_container
 Repository: ghcr.io/elektrobit
 Base-Container: ubuntu:22.04
-Version: v1.4.10
+Version: v1.4.11
 Layers:
   - ../layers/base
   - ../layers/yocto

--- a/configuration/build_config.yaml
+++ b/configuration/build_config.yaml
@@ -4,6 +4,7 @@ Base-Container: ubuntu:22.04
 Version: v1.4.10
 Layers:
   - ../layers/base
+  - ../layers/yocto
   - ../layers/pbuilder
   - ../layers/kiwi
   - ../layers/appdev

--- a/layers/base/Dockerfile
+++ b/layers/base/Dockerfile
@@ -33,7 +33,8 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y \
     qemu-system-arm qemu-system-x86 \
     libc6:arm64 \
     software-properties-common ca-certificates \
-    psmisc procps
+    psmisc procps \
+    zip squashfs-tools tzdata
 
 RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/bin
 # add addon ppa

--- a/layers/build_tools/Dockerfile
+++ b/layers/build_tools/Dockerfile
@@ -40,7 +40,7 @@ RUN pip install jsonpickle robotframework requests pyyaml psutil
 
 # Install EBcl build tools
 WORKDIR /build
-RUN git clone --branch v1.3.8 https://github.com/Elektrobit/ebcl_build_tools ebcl_build_tools
+RUN git clone --branch v1.3.9 https://github.com/Elektrobit/ebcl_build_tools ebcl_build_tools
 RUN pip install -e ebcl_build_tools
 
 # Prepare cache folders

--- a/layers/yocto/Dockerfile
+++ b/layers/yocto/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:latest
+
+ARG CONTAINER_USER="ebcl"
+
+USER root
+
+# Install Debian tools
+RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y \
+build-essential chrpath cpio debianutils diffstat file gawk gcc git iputils-ping \
+libacl1 liblz4-tool locales python3 python3-git python3-jinja2 python3-pexpect \
+python3-pip python3-subunit socat texinfo unzip wget xz-utils zstd \
+kas
+
+USER $CONTAINER_USER

--- a/tests/rust.robot
+++ b/tests/rust.robot
@@ -9,10 +9,12 @@ Keyword Tags    rust
 
 SDK shall provide rustc
     [Tags]    fast
+    Skip    rust support removed
     Rustc Is Available
 
 SDK shall provide cargo
     [Tags]    fast
+    Skip    rust support removed
     Cargo Is Available
 
 *** Keywords ***


### PR DESCRIPTION
# Changes

- Add Yocto and kas support
- Remove rust support
- Add zip, squashfs-tools and tzdata packages
- Increase version tag to v1.4.11

# Dependencies:

# Tests results

```bash
SDK shall provide rustc                                               | SKIP |
rust support removed
------------------------------------------------------------------------------
SDK shall provide cargo                                               | SKIP |
rust support removed
------------------------------------------------------------------------------
RUNNER: docker
Error response from daemon: Cannot kill container: ebcl_dev_container: Container 895d78aebe8c70ccc48abc14e7a89fe6de2a63cee89d632cd9e4f0d9a7267ca8 is not running
Base & Build & Kiwi & Rust.Rust                                       | SKIP |
2 tests, 0 passed, 0 failed, 2 skipped
==============================================================================
Base & Build & Kiwi & Rust                                            | PASS |
7 tests, 5 passed, 0 failed, 2 skipped
==============================================================================
Output:  /home/tom/ebcl/ebcl_dev_container/tests/output.xml
Log:     /home/tom/ebcl/ebcl_dev_container/tests/log.html
Report:  /home/tom/ebcl/ebcl_dev_container/tests/report.html
```
# Developer Checklist:

- [x] Test: Changes are tested
- N/A Doc: Documentation has been updated 
- [x] Git: Informative git commit message(s)
- N/A Issue: If a related GitHub issue exists, linking is done

# Reviewer checklist:
- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer 
