### PR TITLE
ebclfsa: fix toolchain

### DIFF
--- a/layers/ebclfsa/conf/cmake/toolchain-ebclfsa-aarch64.cmake
+++ b/layers/ebclfsa/conf/cmake/toolchain-ebclfsa-aarch64.cmake
@@ -6,17 +6,20 @@ set(CMAKE_CXX_COMPILER clang++)
 
 set(CMAKE_SYSROOT /build/sysroot_hi_aarch64)
 
+set(GCC_LIBS /usr/lib/gcc-cross/aarch64-linux-gnu/11)
+set(MUSL_LIBS /usr/lib/aarch64-linux-musl)
+set(MUSL_INCLUDE /usr/include/aarch64-linux-musl)
+
 # Only static binaries are allowed
 set(CMAKE_C_FLAGS "-static")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -isystem /usr/include/aarch64-linux-musl/ -isystem /usr/lib/gcc-cross/aarch64-linux-gnu/11/include/")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -isystem ${MUSL_INCLUDE}")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -target aarch64-linux-musl")
 
-set(CMAKE_EXE_LINKER_FLAGS "-fuse-ld=lld -nostdlib -L/usr/lib/aarch64-linux-musl -L/usr/lib/gcc-cross/aarch64-linux-gnu/11 -lc -lgcc")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /usr/lib/aarch64-linux-musl/crt1.o /usr/lib/aarch64-linux-musl/crti.o /usr/lib/aarch64-linux-musl/crtn.o /usr/lib/gcc-cross/aarch64-linux-gnu/11/crtend.o /usr/lib/gcc-cross/aarch64-linux-gnu/11/crtbeginT.o")
+set(CMAKE_EXE_LINKER_FLAGS "-fuse-ld=lld -nostdlib -L${MUSL_LIBS} -L ${GCC_LIBS} -lc -lgcc -lgcc_eh")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${MUSL_LIBS}/Scrt1.o ${MUSL_LIBS}/crti.o ${GCC_LIBS}/crtbeginS.o ${GCC_LIBS}/crtendS.o ${MUSL_LIBS}/crtn.o")
 
 set(CMAKE_FIND_ROOT_PATH "${CMAKE_SYSROOT}")
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 
-set(CMAKE_INSTALL_PREFIX "/" CACHE STRING "Install prefix" FORCE)


### PR DESCRIPTION
 * Remove gcc includes, they are  not required and can lead to compilation errors
 * Change to Scrt1.o and crtbeginS.o and crtendS.o: These are the variants used by musl's spec
 * Use variables for increased readability
 * Drop install prefix: With the introduction of mixed criticality, setting the install prefix to / does not make sense anymore

Main reason for this change is the removal of the gcc include directory, because that triggered an error when building the userland utils.
The install prefix has no impact on the current ebclfsa demo app, because it sets the install path in its cmake files.