### PR TITLE
Container v1.5.1: Upgrade build tools to v1.3.14

### DIFF
--- a/configuration/build_config.yaml
+++ b/configuration/build_config.yaml
@@ -1,7 +1,7 @@
 Base-Name: ebcl_dev_container
 Repository: ghcr.io/elektrobit
 Base-Container: ubuntu:22.04
-Version: v1.5.0
+Version: v1.5.1
 Version_packages: 1.5
 Layers:
   - ../layers/base

--- a/layers/build_tools/Dockerfile
+++ b/layers/build_tools/Dockerfile
@@ -40,7 +40,7 @@ RUN pip install jsonpickle robotframework requests pyyaml psutil
 
 # Install EBcl build tools
 WORKDIR /build
-RUN git clone --branch v1.3.13 https://github.com/Elektrobit/ebcl_build_tools ebcl_build_tools
+RUN git clone --branch v1.3.14 https://github.com/Elektrobit/ebcl_build_tools ebcl_build_tools
 RUN pip install -e ebcl_build_tools
 
 # Prepare cache folders


### PR DESCRIPTION
# Changes

- Upgrade build tools to v1.3.14
- Increase container version to v.1.5.1

Fixes https://github.com/Elektrobit/ebcl_build_tools/issues/66 

# Dependencies:

None

# Tests results

```bash
tom@del01171:~/ebcl/work_2.x/ebcl_dev_container/tests$ ./run_tests 
Current directory: /home/tom/ebcl/work_2.x/ebcl_dev_container/tests
Requirement already satisfied: docker==7.1.0 in /home/tom/ebcl/work_2.x/ebcl_dev_container/.venv/lib/python3.10/site-packages (from -r /home/tom/ebcl/work_2.x/ebcl_dev_container/requirements.txt (line 1)) (7.1.0)
Requirement already satisfied: PyYAML==6.0.2 in /home/tom/ebcl/work_2.x/ebcl_dev_container/.venv/lib/python3.10/site-packages (from -r /home/tom/ebcl/work_2.x/ebcl_dev_container/requirements.txt (line 2)) (6.0.2)
Requirement already satisfied: robotframework==7.1 in /home/tom/ebcl/work_2.x/ebcl_dev_container/.venv/lib/python3.10/site-packages (from -r /home/tom/ebcl/work_2.x/ebcl_dev_container/requirements.txt (line 3)) (7.1)
Requirement already satisfied: types-PyYAML==6.0.12.20240917 in /home/tom/ebcl/work_2.x/ebcl_dev_container/.venv/lib/python3.10/site-packages (from -r /home/tom/ebcl/work_2.x/ebcl_dev_container/requirements.txt (line 4)) (6.0.12.20240917)
Requirement already satisfied: urllib3>=1.26.0 in /home/tom/ebcl/work_2.x/ebcl_dev_container/.venv/lib/python3.10/site-packages (from docker==7.1.0->-r /home/tom/ebcl/work_2.x/ebcl_dev_container/requirements.txt (line 1)) (2.3.0)
Requirement already satisfied: requests>=2.26.0 in /home/tom/ebcl/work_2.x/ebcl_dev_container/.venv/lib/python3.10/site-packages (from docker==7.1.0->-r /home/tom/ebcl/work_2.x/ebcl_dev_container/requirements.txt (line 1)) (2.32.3)
Requirement already satisfied: idna<4,>=2.5 in /home/tom/ebcl/work_2.x/ebcl_dev_container/.venv/lib/python3.10/site-packages (from requests>=2.26.0->docker==7.1.0->-r /home/tom/ebcl/work_2.x/ebcl_dev_container/requirements.txt (line 1)) (3.10)
Requirement already satisfied: charset-normalizer<4,>=2 in /home/tom/ebcl/work_2.x/ebcl_dev_container/.venv/lib/python3.10/site-packages (from requests>=2.26.0->docker==7.1.0->-r /home/tom/ebcl/work_2.x/ebcl_dev_container/requirements.txt (line 1)) (3.4.1)
Requirement already satisfied: certifi>=2017.4.17 in /home/tom/ebcl/work_2.x/ebcl_dev_container/.venv/lib/python3.10/site-packages (from requests>=2.26.0->docker==7.1.0->-r /home/tom/ebcl/work_2.x/ebcl_dev_container/requirements.txt (line 1)) (2025.1.31)
Running the tests for dev container v1.5.1...
==============================================================================
Base & Build & Kiwi & Rust                                                    
==============================================================================
Base & Build & Kiwi & Rust.Base                                               
==============================================================================
RUNNER: docker
Using images from /home/tom/ebcl/work_2.x/ebcl_dev_container/usage/images.
Using /home/tom/ebcl/work_2.x/ebcl_dev_container/usage/results as result folder.
Using workspace from /home/tom/ebcl/work_2.x/ebcl_dev_container/usage.
Dev container image ghcr.io/elektrobit/ebcl_dev_container:v1.5.1 is available.
CONTAINER_NAME: ebcl_dev_container
Stopping and deleting the container...
Running the container as background process...
SDK version shall match the container version                         | PASS |
------------------------------------------------------------------------------
SDK user shall be ebcl                                                | PASS |
------------------------------------------------------------------------------
SDK shall provide a proper Debian environment                         | PASS |
------------------------------------------------------------------------------
RUNNER: docker
Error response from daemon: cannot kill container: ebcl_dev_container: container 7abba51afd405ee8d05b9b9131a9a107c440663e0b43c6958ff1cc6d5fee5645 is not running
Base & Build & Kiwi & Rust.Base                                       | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
Base & Build & Kiwi & Rust.Build                                              
==============================================================================
Containers shall build                                                Current directory: /home/tom/ebcl/work_2.x/ebcl_dev_container/builder
Requirement already satisfied: docker==7.1.0 in /home/tom/ebcl/work_2.x/ebcl_dev_container/.venv/lib/python3.10/site-packages (from -r /home/tom/ebcl/work_2.x/ebcl_dev_container/requirements.txt (line 1)) (7.1.0)
Requirement already satisfied: PyYAML==6.0.2 in /home/tom/ebcl/work_2.x/ebcl_dev_container/.venv/lib/python3.10/site-packages (from -r /home/tom/ebcl/work_2.x/ebcl_dev_container/requirements.txt (line 2)) (6.0.2)
Requirement already satisfied: robotframework==7.1 in /home/tom/ebcl/work_2.x/ebcl_dev_container/.venv/lib/python3.10/site-packages (from -r /home/tom/ebcl/work_2.x/ebcl_dev_container/requirements.txt (line 3)) (7.1)
Requirement already satisfied: types-PyYAML==6.0.12.20240917 in /home/tom/ebcl/work_2.x/ebcl_dev_container/.venv/lib/python3.10/site-packages (from -r /home/tom/ebcl/work_2.x/ebcl_dev_container/requirements.txt (line 4)) (6.0.12.20240917)
Requirement already satisfied: requests>=2.26.0 in /home/tom/ebcl/work_2.x/ebcl_dev_container/.venv/lib/python3.10/site-packages (from docker==7.1.0->-r /home/tom/ebcl/work_2.x/ebcl_dev_container/requirements.txt (line 1)) (2.32.3)
Requirement already satisfied: urllib3>=1.26.0 in /home/tom/ebcl/work_2.x/ebcl_dev_container/.venv/lib/python3.10/site-packages (from docker==7.1.0->-r /home/tom/ebcl/work_2.x/ebcl_dev_container/requirements.txt (line 1)) (2.3.0)
Requirement already satisfied: charset-normalizer<4,>=2 in /home/tom/ebcl/work_2.x/ebcl_dev_container/.venv/lib/python3.10/site-packages (from requests>=2.26.0->docker==7.1.0->-r /home/tom/ebcl/work_2.x/ebcl_dev_container/requirements.txt (line 1)) (3.4.1)
Requirement already satisfied: certifi>=2017.4.17 in /home/tom/ebcl/work_2.x/ebcl_dev_container/.venv/lib/python3.10/site-packages (from requests>=2.26.0->docker==7.1.0->-r /home/tom/ebcl/work_2.x/ebcl_dev_container/requirements.txt (line 1)) (2025.1.31)
Requirement already satisfied: idna<4,>=2.5 in /home/tom/ebcl/work_2.x/ebcl_dev_container/.venv/lib/python3.10/site-packages (from requests>=2.26.0->docker==7.1.0->-r /home/tom/ebcl/work_2.x/ebcl_dev_container/requirements.txt (line 1)) (3.10)
Building EBcL SDK dev container...
INFO:root:Conifg: {'Base-Name': 'ebcl_dev_container', 'Repository': 'ghcr.io/elektrobit', 'Base-Container': 'ubuntu:22.04', 'Version': 'v1.5.1', 'Version_packages': 1.5, 'Layers': ['../layers/base', '../layers/yocto', '../layers/pbuilder', '../layers/kiwi', '../layers/appdev', '../layers/build_tools', '../layers/vscode', '../layers/ebclfsa', '../layers/kernel', '../layers/squash']}
INFO:root:Builder: docker
INFO:root:Building layer ghcr.io/elektrobit/ebcl_dev_container_base:v1.5.1.
[+] Building 0.2s (40/40) FINISHED                                                                                                                                                                                   docker:default
 => [internal] load build definition from Dockerfile.tmp                                                                                                                                                                       0.0s
 => => transferring dockerfile: 3.63kB                                                                                                                                                                                         0.0s
 => [internal] load metadata for docker.io/library/ubuntu:22.04                                                                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                                                0.0s
 => [internal] load build context                                                                                                                                                                                              0.0s
 => => transferring context: 10.32kB                                                                                                                                                                                           0.0s
 => [ 1/35] FROM docker.io/library/ubuntu:22.04                                                                                                                                                                                0.0s
 => CACHED [ 2/35] RUN rm -rf /etc/apt/sources.list                                                                                                                                                                            0.0s
 => CACHED [ 3/35] COPY conf/apt/sources.list /etc/apt/sources.list                                                                                                                                                            0.0s
 => CACHED [ 4/35] RUN mkdir -p /etc/apt/trusted.gpg.d                                                                                                                                                                         0.0s
 => CACHED [ 5/35] COPY conf/apt-keys/elektrobit.gpg /etc/apt/trusted.gpg.d/                                                                                                                                                   0.0s
 => CACHED [ 6/35] RUN mkdir -p /etc/apt/sources.list.d                                                                                                                                                                        0.0s
 => CACHED [ 7/35] COPY conf/apt/elektrobit.list /etc/apt/sources.list.d/                                                                                                                                                      0.0s
 => CACHED [ 8/35] RUN sed -i "s/VERSION/1.5/g" /etc/apt/sources.list.d/elektrobit.list                                                                                                                                        0.0s
 => CACHED [ 9/35] RUN cat /etc/apt/sources.list.d/elektrobit.list                                                                                                                                                             0.0s
 => CACHED [10/35] RUN dpkg --add-architecture arm64                                                                                                                                                                           0.0s
 => CACHED [11/35] RUN apt update                                                                                                                                                                                              0.0s
 => CACHED [12/35] RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y     build-essential gcc g++ cmake pkg-config gdb-multiarch     gcc-aarch64-linux-gnu g++-aarch64-linux-gnu crossbuild-essential-arm64     loc  0.0s
 => CACHED [13/35] RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/bin                                                                                                                            0.0s
 => CACHED [14/35] RUN add-apt-repository ppa:elos-team/ppa                                                                                                                                                                    0.0s
 => CACHED [15/35] RUN apt update                                                                                                                                                                                              0.0s
 => CACHED [16/35] RUN export LC_ALL=en_US.UTF-8 &&     export LANG=en_US.UTF-8 &&     locale-gen en_US.UTF-8                                                                                                                  0.0s
 => CACHED [17/35] RUN userdel ubuntu || true                                                                                                                                                                                  0.0s
 => CACHED [18/35] RUN addgroup --gid 1000 ebcl &&   useradd -rm -d /home/ebcl -s /bin/bash -g ebcl -G sudo -u 1000 ebcl &&   echo "ebcl ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers &&   mkdir -p /home/ebcl/.ssh &&   chown  0.0s
 => CACHED [19/35] RUN mkdir -p /build/results/images &&     mkdir -p results/packages &&     mkdir -p images &&     mkdir -p identity &&     mkdir -p bin &&     chown -R ebcl:ebcl /build                                    0.0s
 => CACHED [20/35] RUN mkdir -p /workspace &&     chown -R ebcl:ebcl /workspace                                                                                                                                                0.0s
 => CACHED [21/35] RUN mkdir -p /home/ebcl/.ssh &&     chown -R ebcl:ebcl /home/ebcl                                                                                                                                           0.0s
 => CACHED [22/35] COPY conf/bash/bashrc /home/ebcl/.bashrc                                                                                                                                                                    0.0s
 => CACHED [23/35] RUN chown -R ebcl:ebcl /home/ebcl &&     chmod +x /home/ebcl/.bashrc                                                                                                                                        0.0s
 => CACHED [24/35] RUN mkdir -p /root                                                                                                                                                                                          0.0s
 => CACHED [25/35] COPY conf/bash/bashrc /root/.bashrc                                                                                                                                                                         0.0s
 => CACHED [26/35] RUN chown -R root:root /root &&     chmod +x /root/.bashrc                                                                                                                                                  0.0s
 => CACHED [27/35] COPY scripts/bash/* /build/bin/                                                                                                                                                                             0.0s
 => CACHED [28/35] COPY scripts/gpg/* /build/bin/                                                                                                                                                                              0.0s
 => CACHED [29/35] COPY scripts/qemu/* /build/bin/                                                                                                                                                                             0.0s
 => CACHED [30/35] COPY scripts/mount/* /build/bin/                                                                                                                                                                            0.0s
 => CACHED [31/35] RUN chown -R ebcl:ebcl /build/bin &&     chmod +x /build/bin/*                                                                                                                                              0.0s
 => CACHED [32/35] RUN echo v1.5.1 > /etc/sdk_version                                                                                                                                                                          0.0s
 => CACHED [33/35] RUN python3 -m venv /build/venv                                                                                                                                                                             0.0s
 => CACHED [34/35] RUN pip install mypy pep8 pylint pytest pytest-cov robotframework                                                                                                                                           0.0s
 => CACHED [35/35] RUN chown -R ebcl:ebcl /build/venv                                                                                                                                                                          0.0s
 => exporting to image                                                                                                                                                                                                         0.0s
 => => exporting layers                                                                                                                                                                                                        0.0s
 => => writing image sha256:85b50e14338e6c7b15e43b8804f680ae083b9a53ba4fe62a12b1476cba1abeeb                                                                                                                                   0.0s
 => => naming to ghcr.io/elektrobit/ebcl_dev_container_base:v1.5.1                                                                                                                                                             0.0s
INFO:root:Building layer ghcr.io/elektrobit/ebcl_dev_container_yocto:v1.5.1.
[+] Building 0.1s (6/6) FINISHED                                                                                                                                                                                     docker:default
 => [internal] load build definition from Dockerfile.tmp                                                                                                                                                                       0.0s
 => => transferring dockerfile: 505B                                                                                                                                                                                           0.0s
 => [internal] load metadata for ghcr.io/elektrobit/ebcl_dev_container_base:v1.5.1                                                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                                                0.0s
 => [1/2] FROM ghcr.io/elektrobit/ebcl_dev_container_base:v1.5.1                                                                                                                                                               0.0s
 => CACHED [2/2] RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y build-essential chrpath cpio debianutils diffstat file gawk gcc git iputils-ping libacl1 liblz4-tool locales python3 python3-git python3-jinja2  0.0s
 => exporting to image                                                                                                                                                                                                         0.0s
 => => exporting layers                                                                                                                                                                                                        0.0s
 => => writing image sha256:564b4daff6b8a10a2ab3f2a11334679d4d5685ee38575778817f665301edd2ec                                                                                                                                   0.0s
 => => naming to ghcr.io/elektrobit/ebcl_dev_container_yocto:v1.5.1                                                                                                                                                            0.0s
INFO:root:Building layer ghcr.io/elektrobit/ebcl_dev_container_pbuilder:v1.5.1.
[+] Building 0.1s (19/19) FINISHED                                                                                                                                                                                   docker:default
 => [internal] load build definition from Dockerfile.tmp                                                                                                                                                                       0.0s
 => => transferring dockerfile: 1.45kB                                                                                                                                                                                         0.0s
 => [internal] load metadata for ghcr.io/elektrobit/ebcl_dev_container_yocto:v1.5.1                                                                                                                                            0.0s
 => [internal] load .dockerignore                                                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                                                0.0s
 => [internal] load build context                                                                                                                                                                                              0.0s
 => => transferring context: 7.09kB                                                                                                                                                                                            0.0s
 => [ 1/14] FROM ghcr.io/elektrobit/ebcl_dev_container_yocto:v1.5.1                                                                                                                                                            0.0s
 => CACHED [ 2/14] RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y     dh-make devscripts pbuilder                                                                                                                0.0s
 => CACHED [ 3/14] COPY conf/pbuilder/pbuilderrc /home/ebcl/.pbuilderrc                                                                                                                                                        0.0s
 => CACHED [ 4/14] RUN sudo chown ebcl:ebcl /home/ebcl/.pbuilderrc && chmod +x /home/ebcl/.pbuilderrc                                                                                                                          0.0s
 => CACHED [ 5/14] RUN sed -i "s/VERSION/1.5/g" /home/ebcl/.pbuilderrc                                                                                                                                                         0.0s
 => CACHED [ 6/14] RUN mkdir -p /home/ebcl/.pbuilder/hooks/                                                                                                                                                                    0.0s
 => CACHED [ 7/14] COPY conf/pbuilder/G99apt_arch /home/ebcl/.pbuilder/hooks/G99apt_arch                                                                                                                                       0.0s
 => CACHED [ 8/14] RUN sudo chown ebcl:ebcl /home/ebcl/.pbuilder/hooks/* && chmod +x /home/ebcl/.pbuilder/hooks/*                                                                                                              0.0s
 => CACHED [ 9/14] RUN sudo ln -s /home/ebcl/.pbuilderrc /root/.pbuilderrc                                                                                                                                                     0.0s
 => CACHED [10/14] COPY scripts/deb/* /build/bin/                                                                                                                                                                              0.0s
 => CACHED [11/14] COPY scripts/pbuilder/* /build/bin/                                                                                                                                                                         0.0s
 => CACHED [12/14] RUN chown -R ebcl:ebcl /build/bin &&     chmod +x /build/bin/*                                                                                                                                              0.0s
 => CACHED [13/14] RUN gpg --no-default-keyring --keyring trustedkeys.gpg --import /etc/apt/trusted.gpg.d/elektrobit.gpg                                                                                                       0.0s
 => CACHED [14/14] RUN gpg --no-default-keyring --keyring trustedkeys.gpg --import /etc/apt/trusted.gpg.d/ubuntu-keyring-2018-archive.gpg                                                                                      0.0s
 => exporting to image                                                                                                                                                                                                         0.0s
 => => exporting layers                                                                                                                                                                                                        0.0s
 => => writing image sha256:4cbc8046a1b575f232cf109e247ea6154965ec50f8bce8b5d3289aa912839982                                                                                                                                   0.0s
 => => naming to ghcr.io/elektrobit/ebcl_dev_container_pbuilder:v1.5.1                                                                                                                                                         0.0s
INFO:root:Building layer ghcr.io/elektrobit/ebcl_dev_container_kiwi:v1.5.1.
[+] Building 0.1s (20/20) FINISHED                                                                                                                                                                                   docker:default
 => [internal] load build definition from Dockerfile.tmp                                                                                                                                                                       0.0s
 => => transferring dockerfile: 1.12kB                                                                                                                                                                                         0.0s
 => [internal] load metadata for ghcr.io/elektrobit/ebcl_dev_container_pbuilder:v1.5.1                                                                                                                                         0.0s
 => [internal] load .dockerignore                                                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                                                0.0s
 => [internal] load build context                                                                                                                                                                                              0.0s
 => => transferring context: 13.16kB                                                                                                                                                                                           0.0s
 => [ 1/15] FROM ghcr.io/elektrobit/ebcl_dev_container_pbuilder:v1.5.1                                                                                                                                                         0.0s
 => CACHED [ 2/15] RUN mkdir -p /etc/berrymill                                                                                                                                                                                 0.0s
 => CACHED [ 3/15] COPY conf/berrymill/berrymill_local.conf /etc/berrymill                                                                                                                                                     0.0s
 => CACHED [ 4/15] COPY conf/berrymill/berrymill.conf /etc/berrymill                                                                                                                                                           0.0s
 => CACHED [ 5/15] COPY conf/kiwi/kiwi-boxed-plugin.yml /etc/berrymill                                                                                                                                                         0.0s
 => CACHED [ 6/15] COPY conf/kiwi/kiwi.yml /etc                                                                                                                                                                                0.0s
 => CACHED [ 7/15] RUN mkdir -p /etc/berrymill/keyrings.d                                                                                                                                                                      0.0s
 => CACHED [ 8/15] RUN cp /etc/apt/trusted.gpg.d/elektrobit.gpg /etc/berrymill/keyrings.d/                                                                                                                                     0.0s
 => CACHED [ 9/15] WORKDIR /build                                                                                                                                                                                              0.0s
 => CACHED [10/15] RUN pip install kiwi==10.1.2 kiwi-boxed-plugin==0.2.36                                                                                                                                                      0.0s
 => CACHED [11/15] RUN pip install 'berrymill @ git+https://github.com/tomirgang/berrymill.git@f4ff87f08edf5f178284a5a689e2b6e301faad35'                                                                                       0.0s
 => CACHED [12/15] COPY scripts/apt/* /build/bin/                                                                                                                                                                              0.0s
 => CACHED [13/15] COPY scripts/berrymill/* /build/bin/                                                                                                                                                                        0.0s
 => CACHED [14/15] COPY scripts/gpg/* /build/bin/                                                                                                                                                                              0.0s
 => CACHED [15/15] COPY scripts/kiwi/* /build/bin/                                                                                                                                                                             0.0s
 => exporting to image                                                                                                                                                                                                         0.0s
 => => exporting layers                                                                                                                                                                                                        0.0s
 => => writing image sha256:bc3d5929edcab200b671bd90a7768bc1f9ff9beff223fc71f73d6cdf14a18a8e                                                                                                                                   0.0s
 => => naming to ghcr.io/elektrobit/ebcl_dev_container_kiwi:v1.5.1                                                                                                                                                             0.0s
INFO:root:Building layer ghcr.io/elektrobit/ebcl_dev_container_appdev:v1.5.1.
[+] Building 0.2s (15/15) FINISHED                                                                                                                                                                                   docker:default
 => [internal] load build definition from Dockerfile.tmp                                                                                                                                                                       0.0s
 => => transferring dockerfile: 944B                                                                                                                                                                                           0.0s
 => [internal] load metadata for ghcr.io/elektrobit/ebcl_dev_container_kiwi:v1.5.1                                                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                                                0.0s
 => [ 1/10] FROM ghcr.io/elektrobit/ebcl_dev_container_kiwi:v1.5.1                                                                                                                                                             0.0s
 => [internal] load build context                                                                                                                                                                                              0.0s
 => => transferring context: 5.00kB                                                                                                                                                                                            0.0s
 => CACHED [ 2/10] RUN apt -y install libjsoncpp-dev                                                                                                                                                                           0.0s
 => CACHED [ 3/10] RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null                                        0.0s
 => CACHED [ 4/10] RUN echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null                                 0.0s
 => CACHED [ 5/10] RUN apt-get update && apt -y install cmake sshpass rsync                                                                                                                                                    0.0s
 => CACHED [ 6/10] WORKDIR /build                                                                                                                                                                                              0.0s
 => CACHED [ 7/10] RUN mkdir -p /build/cmake                                                                                                                                                                                   0.0s
 => CACHED [ 8/10] COPY conf/cmake/* /build/cmake/                                                                                                                                                                             0.0s
 => CACHED [ 9/10] COPY scripts/cmake/* /build/bin/                                                                                                                                                                            0.0s
 => CACHED [10/10] RUN mkdir -p /build/results/apps                                                                                                                                                                            0.0s
 => exporting to image                                                                                                                                                                                                         0.0s
 => => exporting layers                                                                                                                                                                                                        0.0s
 => => writing image sha256:5f3f23c3eb22be5e69e383ada5119ec456084bd22df0a79d73712e6555832320                                                                                                                                   0.0s
 => => naming to ghcr.io/elektrobit/ebcl_dev_container_appdev:v1.5.1                                                                                                                                                           0.0s
INFO:root:Building layer ghcr.io/elektrobit/ebcl_dev_container_build_tools:v1.5.1.
[+] Building 0.2s (23/23) FINISHED                                                                                                                                                                                   docker:default
 => [internal] load build definition from Dockerfile.tmp                                                                                                                                                                       0.0s
 => => transferring dockerfile: 1.38kB                                                                                                                                                                                         0.0s
 => [internal] load metadata for ghcr.io/elektrobit/ebcl_dev_container_appdev:v1.5.1                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                                                0.0s
 => [ 1/18] FROM ghcr.io/elektrobit/ebcl_dev_container_appdev:v1.5.1                                                                                                                                                           0.0s
 => [internal] load build context                                                                                                                                                                                              0.0s
 => => transferring context: 3.26kB                                                                                                                                                                                            0.0s
 => CACHED [ 2/18] RUN apt -y install     python3 python3-pip python3-venv libparted-dev python3-dev pkg-config     mtools e2fsprogs cryptsetup-bin dosfstools fakeroot fdisk udev cpio                                        0.0s
 => CACHED [ 3/18] RUN pip install pyyaml types-PyYAML     requests types-requests     Jinja2 types-Jinja2     unix-ar zstandard                                                                                               0.0s
 => CACHED [ 4/18] WORKDIR /build                                                                                                                                                                                              0.0s
 => CACHED [ 5/18] RUN git clone --branch v0.1.2 https://github.com/Elektrobit/embdgen.git embdgen                                                                                                                             0.0s
 => CACHED [ 6/18] WORKDIR /build/embdgen                                                                                                                                                                                      0.0s
 => CACHED [ 7/18] RUN pip install -e embdgen-core                                                                                                                                                                             0.0s
 => CACHED [ 8/18] RUN pip install -e embdgen-cominit                                                                                                                                                                          0.0s
 => CACHED [ 9/18] RUN pip install -e embdgen-config-yaml                                                                                                                                                                      0.0s
 => CACHED [10/18] RUN mkdir -p /build/keys                                                                                                                                                                                    0.0s
 => CACHED [11/18] COPY conf/elektrobit.pub /build/keys/                                                                                                                                                                       0.0s
 => CACHED [12/18] RUN pip install jsonpickle robotframework requests pyyaml psutil                                                                                                                                            0.0s
 => CACHED [13/18] WORKDIR /build                                                                                                                                                                                              0.0s
 => CACHED [14/18] RUN git clone --branch v1.3.14 https://github.com/Elektrobit/ebcl_build_tools ebcl_build_tools                                                                                                              0.0s
 => CACHED [15/18] RUN pip install -e ebcl_build_tools                                                                                                                                                                         0.0s
 => CACHED [16/18] RUN mkdir -p /workspace/state/cache                                                                                                                                                                         0.0s
 => CACHED [17/18] RUN mkdir -p /workspace/state/apt                                                                                                                                                                           0.0s
 => CACHED [18/18] RUN mkdir -p /workspace/state/debootstrap                                                                                                                                                                   0.0s
 => exporting to image                                                                                                                                                                                                         0.0s
 => => exporting layers                                                                                                                                                                                                        0.0s
 => => writing image sha256:ddb6b59ab638cf4284c6c772e0a4404d2e804b12e98041c9ce414d86c1eb7d76                                                                                                                                   0.0s
 => => naming to ghcr.io/elektrobit/ebcl_dev_container_build_tools:v1.5.1                                                                                                                                                      0.0s
INFO:root:Building layer ghcr.io/elektrobit/ebcl_dev_container_vscode:v1.5.1.
[+] Building 0.1s (9/9) FINISHED                                                                                                                                                                                     docker:default
 => [internal] load build definition from Dockerfile.tmp                                                                                                                                                                       0.0s
 => => transferring dockerfile: 486B                                                                                                                                                                                           0.0s
 => [internal] load metadata for ghcr.io/elektrobit/ebcl_dev_container_build_tools:v1.5.1                                                                                                                                      0.0s
 => [internal] load .dockerignore                                                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                                                0.0s
 => [1/5] FROM ghcr.io/elektrobit/ebcl_dev_container_build_tools:v1.5.1                                                                                                                                                        0.0s
 => CACHED [2/5] WORKDIR /build                                                                                                                                                                                                0.0s
 => CACHED [3/5] RUN git clone --branch v1.0.2 https://github.com/Elektrobit/ebcl_vscode_tools.git ebcl_vscode_tools                                                                                                           0.0s
 => CACHED [4/5] RUN pip install -e ebcl_vscode_tools                                                                                                                                                                          0.0s
 => CACHED [5/5] RUN pip install libtmux                                                                                                                                                                                       0.0s
 => exporting to image                                                                                                                                                                                                         0.0s
 => => exporting layers                                                                                                                                                                                                        0.0s
 => => writing image sha256:15d7fa7c05c515fe9dbfad018fdffb24b7e6b9d5dfe94876f2890870e9a2f907                                                                                                                                   0.0s
 => => naming to ghcr.io/elektrobit/ebcl_dev_container_vscode:v1.5.1                                                                                                                                                           0.0s
INFO:root:Building layer ghcr.io/elektrobit/ebcl_dev_container_ebclfsa:v1.5.1.
[+] Building 0.1s (10/10) FINISHED                                                                                                                                                                                   docker:default
 => [internal] load build definition from Dockerfile.tmp                                                                                                                                                                       0.0s
 => => transferring dockerfile: 516B                                                                                                                                                                                           0.0s
 => [internal] load metadata for ghcr.io/elektrobit/ebcl_dev_container_vscode:v1.5.1                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                                                0.0s
 => [internal] load build context                                                                                                                                                                                              0.0s
 => => transferring context: 1.80kB                                                                                                                                                                                            0.0s
 => [1/5] FROM ghcr.io/elektrobit/ebcl_dev_container_vscode:v1.5.1                                                                                                                                                             0.0s
 => CACHED [2/5] COPY conf/apt/ebclfsa.list /etc/apt/sources.list.d/                                                                                                                                                           0.0s
 => CACHED [3/5] RUN apt-get update && apt-get install -y --no-install-recommends     clang     lisa-elf-enabler     lld     llvm     musl-dev:arm64                                                                           0.0s
 => CACHED [4/5] RUN mkdir -p /build/cmake                                                                                                                                                                                     0.0s
 => CACHED [5/5] COPY conf/cmake/* /build/cmake/                                                                                                                                                                               0.0s
 => exporting to image                                                                                                                                                                                                         0.0s
 => => exporting layers                                                                                                                                                                                                        0.0s
 => => writing image sha256:406e2a3f553e4e9e6ce9df8b8c3255410088c219098c245f07ff4e2a7eb397db                                                                                                                                   0.0s
 => => naming to ghcr.io/elektrobit/ebcl_dev_container_ebclfsa:v1.5.1                                                                                                                                                          0.0s
INFO:root:Building layer ghcr.io/elektrobit/ebcl_dev_container_kernel:v1.5.1.
[+] Building 0.1s (6/6) FINISHED                                                                                                                                                                                     docker:default
 => [internal] load build definition from Dockerfile.tmp                                                                                                                                                                       0.0s
 => => transferring dockerfile: 367B                                                                                                                                                                                           0.0s
 => [internal] load metadata for ghcr.io/elektrobit/ebcl_dev_container_ebclfsa:v1.5.1                                                                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                                                0.0s
 => [1/2] FROM ghcr.io/elektrobit/ebcl_dev_container_ebclfsa:v1.5.1                                                                                                                                                            0.0s
 => CACHED [2/2] RUN apt-get update  && apt-get install --no-install-recommends -y     build-essential     flex     bison     bc     libssl-dev     libncurses-dev     rsync     kmod     cpio     make                        0.0s
 => exporting to image                                                                                                                                                                                                         0.0s
 => => exporting layers                                                                                                                                                                                                        0.0s
 => => writing image sha256:4b5a6e861d84c0710234be843c6cd6d233a0e602dd0913332c81dab5eaca186b                                                                                                                                   0.0s
 => => naming to ghcr.io/elektrobit/ebcl_dev_container_kernel:v1.5.1                                                                                                                                                           0.0s
INFO:root:Building layer ghcr.io/elektrobit/ebcl_dev_container_squash:v1.5.1.
[+] Building 0.1s (6/6) FINISHED                                                                                                                                                                                     docker:default
 => [internal] load build definition from Dockerfile.tmp                                                                                                                                                                       0.0s
 => => transferring dockerfile: 173B                                                                                                                                                                                           0.0s
 => [internal] load metadata for ghcr.io/elektrobit/ebcl_dev_container_kernel:v1.5.1                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                                                                0.0s
 => [base_container_name 1/1] FROM ghcr.io/elektrobit/ebcl_dev_container_kernel:v1.5.1                                                                                                                                         0.0s
 => CACHED [stage-1 1/1] COPY --from=base_container_name / /                                                                                                                                                                   0.0s
 => exporting to image                                                                                                                                                                                                         0.0s
 => => exporting layers                                                                                                                                                                                                        0.0s
 => => writing image sha256:8b4f58aabab29c6a78a4a176acf083b96515294fa91e19a7874f6ebd32d317df                                                                                                                                   0.0s
 => => naming to ghcr.io/elektrobit/ebcl_dev_container_squash:v1.5.1                                                                                                                                                           0.0s
INFO:root:Tagging container ghcr.io/elektrobit/ebcl_dev_container_squash:v1.5.1 as ghcr.io/elektrobit/ebcl_dev_container:v1.5.1.
Containers shall build                                                | PASS |
------------------------------------------------------------------------------
Base & Build & Kiwi & Rust.Build                                      | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Base & Build & Kiwi & Rust.Kiwi                                               
==============================================================================
RUNNER: docker
Using images from /home/tom/ebcl/work_2.x/ebcl_dev_container/usage/images.
Using /home/tom/ebcl/work_2.x/ebcl_dev_container/usage/results as result folder.
Using workspace from /home/tom/ebcl/work_2.x/ebcl_dev_container/usage.
Dev container image ghcr.io/elektrobit/ebcl_dev_container:v1.5.1 is available.
CONTAINER_NAME: ebcl_dev_container
Stopping and deleting the container...
Running the container as background process...
SDK shall provide Kiwi-ng and Berrymill                               | PASS |
------------------------------------------------------------------------------
RUNNER: docker
Error response from daemon: cannot kill container: ebcl_dev_container: container 94aeae2d40f49136a98de36458e78326b984d14b602739bf8e6f57f7da36335b is not running
Base & Build & Kiwi & Rust.Kiwi                                       | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Base & Build & Kiwi & Rust.Rust                                               
==============================================================================
RUNNER: docker
Using images from /home/tom/ebcl/work_2.x/ebcl_dev_container/usage/images.
Using /home/tom/ebcl/work_2.x/ebcl_dev_container/usage/results as result folder.
Using workspace from /home/tom/ebcl/work_2.x/ebcl_dev_container/usage.
Dev container image ghcr.io/elektrobit/ebcl_dev_container:v1.5.1 is available.
CONTAINER_NAME: ebcl_dev_container
Stopping and deleting the container...
Running the container as background process...
SDK shall provide rustc                                               | SKIP |
rust support removed
------------------------------------------------------------------------------
SDK shall provide cargo                                               | SKIP |
rust support removed
------------------------------------------------------------------------------
RUNNER: docker
Error response from daemon: cannot kill container: ebcl_dev_container: container bde0a38f3c8e84739fd64e20bea444d578009975f0b45465ea1340b87f6116af is not running
Base & Build & Kiwi & Rust.Rust                                       | SKIP |
2 tests, 0 passed, 0 failed, 2 skipped
==============================================================================
Base & Build & Kiwi & Rust                                            | PASS |
7 tests, 5 passed, 0 failed, 2 skipped
==============================================================================
Output:  /home/tom/ebcl/work_2.x/ebcl_dev_container/tests/output.xml
Log:     /home/tom/ebcl/work_2.x/ebcl_dev_container/tests/log.html
Report:  /home/tom/ebcl/work_2.x/ebcl_dev_container/tests/report.html
```

# Developer Checklist:
- [x] Test: Changes are tested
- N/A Doc: Documentation has been updated 
- [x] Git: Informative git commit message(s)
- [x] Issue: If a related GitHub issue exists, linking is done
      
# Reviewer checklist:
- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer
     
