### PR TITLE
Install clang18 musl libc++

### DIFF
--- a/layers/ebclfsa/Dockerfile
+++ b/layers/ebclfsa/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     lisa-elf-enabler \
     lld \
     patchelf \
-    ninja-build
+    ninja-build \
+    llvm-18-tools
 
 # add cmake toolchains
 RUN mkdir -p /build/cmake
@@ -44,5 +45,6 @@ RUN rm /build/build_clang_libc++_musl.sh \
 
 RUN apt remove -y \
     ninja-build \
-    patchelf
+    patchelf \
+    llvm-18-tools
 

--- a/layers/ebclfsa/Dockerfile
+++ b/layers/ebclfsa/Dockerfile
@@ -8,6 +8,8 @@ USER root
 
 COPY conf/apt/ebclfsa.list /etc/apt/sources.list.d/
 # Install ebclfsa tools
+RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key |  gpg --dearmor -o /usr/share/keyrings/llvm.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/llvm.gpg] http://apt.llvm.org/focal/ llvm-toolchain-focal-18 main" | sudo tee /etc/apt/sources.list.d/llvm.list
 RUN apt-get update && apt-get install -y --no-install-recommends \
     lisa-elf-enabler \
     lld \

--- a/layers/ebclfsa/Dockerfile
+++ b/layers/ebclfsa/Dockerfile
@@ -9,12 +9,40 @@ USER root
 COPY conf/apt/ebclfsa.list /etc/apt/sources.list.d/
 # Install ebclfsa tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    clang \
     lisa-elf-enabler \
     lld \
-    llvm \
-    musl-dev:arm64
-    
+    patchelf \
+    ninja-build
+
 # add cmake toolchains
 RUN mkdir -p /build/cmake
 COPY conf/cmake/* /build/cmake/
+
+COPY conf/scripts/build_clang_libc++_musl.sh /build/build_clang_libc++_musl.sh
+COPY conf/patches/0001-llvm-enable-by-default-musl-libc.patch /build
+COPY conf/patches/0001-musl-cross-add-linux-5.15.183-hash.patch /build
+
+RUN chmod +x /build/build_clang_libc++_musl.sh
+RUN bash /build/build_clang_libc++_musl.sh --check_tools
+RUN bash /build/build_clang_libc++_musl.sh --clone_musl
+RUN bash /build/build_clang_libc++_musl.sh --clone_llvm
+RUN bash /build/build_clang_libc++_musl.sh --build_musl_x86
+RUN bash /build/build_clang_libc++_musl.sh --install_musl_x86
+RUN bash /build/build_clang_libc++_musl.sh --build_musl_aarch64
+RUN bash /build/build_clang_libc++_musl.sh --install_musl_aarch64
+RUN bash /build/build_clang_libc++_musl.sh --build_clang_x86
+RUN bash /build/build_clang_libc++_musl.sh --install_clang_x86
+RUN bash /build/build_clang_libc++_musl.sh --build_clang_aarch64
+RUN bash /build/build_clang_libc++_musl.sh --install_clang_aarch64
+
+#clean the docker images, from unnecesary binaries, files and projects.
+RUN bash /build/build_clang_libc++_musl.sh --clean
+
+RUN rm /build/build_clang_libc++_musl.sh \
+       /build/0001-llvm-enable-by-default-musl-libc.patch \
+       /build/0001-musl-cross-add-linux-5.15.183-hash.patch
+
+RUN apt remove -y \
+    ninja-build \
+    patchelf
+

--- a/layers/ebclfsa/conf/cmake/toolchain-ebclfsa-aarch64.cmake
+++ b/layers/ebclfsa/conf/cmake/toolchain-ebclfsa-aarch64.cmake
@@ -1,25 +1,29 @@
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR aarch64)
 
-set(CMAKE_C_COMPILER clang)
-set(CMAKE_CXX_COMPILER clang++)
+set(MUSL_SYSROOT_PATH /usr/aarch64-linux-musl)
+set(CLANG_ROOT_PATH /usr/aarch64_clang_musl/usr/local)
 
-set(CMAKE_SYSROOT /build/sysroot_hi_aarch64)
+set(LOC_TARGET aarch64-linux-musl)
+set(CLANG_LIBS_1 ${CLANG_ROOT_PATH}/lib)
+set(CLANG_LIBS_2 ${CLANG_ROOT_PATH}/lib/${LOC_TARGET})
+set(MUSL_INCLUDE ${SYSROOT_PATH}/${LOC_TARGET}/include)
+set(CLANG_INCLUDE_1 ${CLANG_ROOT_PATH}/include/c++/v1)
+set(CLANG_INCLUDE_2 ${CLANG_ROOT_PATH}/include/${LOC_TARGET}/c++/v1)
 
-set(GCC_LIBS /usr/lib/gcc-cross/aarch64-linux-gnu/11)
-set(MUSL_LIBS /usr/lib/aarch64-linux-musl)
-set(MUSL_INCLUDE /usr/include/aarch64-linux-musl)
+set(CMAKE_C_COMPILER ${CLANG_ROOT_PATH}/bin/clang)
+set(CMAKE_CXX_COMPILER ${CLANG_ROOT_PATH}/bin/clang++)
+set(CMAKE_LINKER /usr/bin/lld)
+set(CMAKE_SYSROOT ${MUSL_SYSROOT_PATH})
+set(CMAKE_FIND_ROOT_PATH ${MUSL_SYSROOT_PATH})
+
 
 # Only static binaries are allowed
 set(CMAKE_C_FLAGS "-static")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -target ${LOC_TARGET}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -isystem ${CLANG_INCLUDE_1}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -isystem ${CLANG_INCLUDE_2}")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -isystem ${MUSL_INCLUDE}")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -target aarch64-linux-musl")
 
-set(CMAKE_EXE_LINKER_FLAGS "-fuse-ld=lld -nostdlib -L${MUSL_LIBS} -L ${GCC_LIBS} -lc -lgcc -lgcc_eh")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${MUSL_LIBS}/Scrt1.o ${MUSL_LIBS}/crti.o ${GCC_LIBS}/crtbeginS.o ${GCC_LIBS}/crtendS.o ${MUSL_LIBS}/crtn.o")
-
-set(CMAKE_FIND_ROOT_PATH "${CMAKE_SYSROOT}")
-set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
-set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_EXE_LINKER_FLAGS "-stdlib=libc++ -lc++ -lc++abi -lunwind -fuse-ld=lld -L${CLANG_LIBS_1} -L${CLANG_LIBS_2}")
 

--- a/layers/ebclfsa/conf/patches/0001-llvm-enable-by-default-musl-libc.patch
+++ b/layers/ebclfsa/conf/patches/0001-llvm-enable-by-default-musl-libc.patch
@@ -1,0 +1,25 @@
+From f25e7c0b69d2f48c1ac548b1de5223a7752eb819 Mon Sep 17 00:00:00 2001
+From: Victor Diaconu <victor.diaconu@aox.de>
+Date: Tue, 20 May 2025 07:16:21 +0000
+Subject: [PATCH] llvm: enable by default musl libc
+
+---
+ libcxx/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libcxx/CMakeLists.txt b/libcxx/CMakeLists.txt
+index d392e95077ac..cc436082caeb 100644
+--- a/libcxx/CMakeLists.txt
++++ b/libcxx/CMakeLists.txt
+@@ -295,7 +295,7 @@ option(LIBCXX_ENABLE_THREADS "Build libc++ with support for threads." ON)
+ option(LIBCXX_ENABLE_MONOTONIC_CLOCK
+   "Build libc++ with support for a monotonic clock.
+    This option may only be set to OFF when LIBCXX_ENABLE_THREADS=OFF." ON)
+-option(LIBCXX_HAS_MUSL_LIBC "Build libc++ with support for the Musl C library" OFF)
++option(LIBCXX_HAS_MUSL_LIBC "Build libc++ with support for the Musl C library" ON)
+ option(LIBCXX_HAS_PTHREAD_API "Ignore auto-detection and force use of pthread API" OFF)
+ option(LIBCXX_HAS_WIN32_THREAD_API "Ignore auto-detection and force use of win32 thread API" OFF)
+ option(LIBCXX_HAS_EXTERNAL_THREAD_API
+-- 
+2.34.1
+

--- a/layers/ebclfsa/conf/patches/0001-musl-cross-add-linux-5.15.183-hash.patch
+++ b/layers/ebclfsa/conf/patches/0001-musl-cross-add-linux-5.15.183-hash.patch
@@ -1,0 +1,20 @@
+From a5ce7cba38be9f0c9e305109532ff09cc7760d64 Mon Sep 17 00:00:00 2001
+From: Elektrobit <inquiries@elektrobit.com>
+Date: Thu, 22 May 2025 11:45:46 +0000
+Subject: [PATCH] musl-cross: add linux 5.15.183 hash
+
+---
+ hashes/linux-5.15.183.tar.xz.sha1 | 1 +
+ 1 file changed, 1 insertion(+)
+ create mode 100644 hashes/linux-5.15.183.tar.xz.sha1
+
+diff --git a/hashes/linux-5.15.183.tar.xz.sha1 b/hashes/linux-5.15.183.tar.xz.sha1
+new file mode 100644
+index 0000000..77fe25c
+--- /dev/null
++++ b/hashes/linux-5.15.183.tar.xz.sha1
+@@ -0,0 +1 @@
++d9a01720c4a11d4adcc41bd12745cfc32e477be9  linux-5.15.183.tar.xz
+-- 
+2.34.1
+

--- a/layers/ebclfsa/conf/scripts/build_clang_libc++_musl.sh
+++ b/layers/ebclfsa/conf/scripts/build_clang_libc++_musl.sh
@@ -1,0 +1,373 @@
+#!/bin/bash
+
+#Overview
+#The default Clang installation on Ubuntu uses GNU libraries, which are not compatible with building LLVM runtimes for musl.
+#To solve this, we first need to build a Clang toolchain for the host machine (x86_64) using musl, and then use that to build a Clang toolchain with runtimes for the aarch64-musl target.
+
+#1. Build musl sysroot for x86_64-linux-musl using musl-cross-make
+
+#Step 1a: Create a config.mak file with the following content:
+#    TARGET = x86_64-linux-musl
+#    GCC_VER = 12.4.0
+#    MUSL_VER = 1.2.5
+#    BINUTILS_VER = 2.33.1
+#    OUTPUT = /workspace/musl-cross-make/output-x86_64
+
+#Step 1b: Build the musl sysroot
+#    make && make install
+
+#2. Build musl sysroot for aarch64-linux-musl using musl-cross-make
+
+#Step 2a: Create a second config.mak file:
+#    TARGET = aarch64-linux-musl
+#    GCC_VER = 12.4.0
+#    MUSL_VER = 1.2.5
+#    BINUTILS_VER = 2.33.1
+#    OUTPUT = /workspace/musl-cross-make/output-aarch64
+
+#Step 2b: Build the musl sysroot
+#    make && make install
+
+#Step 2c: Adjust the sysroot if needed
+#You may need to move or symlink specific libraries.
+#    Example: link libc
+#    ln -s /workspace/musl-cross-make/output-aarch64/aarch64-linux-musl/lib/libc.a /some/target/path/
+
+#3. Build Clang for x86_64-musl using the musl sysroot
+
+#Step 3a: Create a CMake toolchain file toolchain-x86_64-musl.cmake
+#(See this file for full details)
+
+#Step 3b: Run your first CMake configuration to build Clang using musl
+#cmake -G "Unix Makefiles" -S llvm -B build_x86_64_clang_musl \
+#    -DLLVM_ENABLE_PROJECTS="clang" \
+#    -DCMAKE_TOOLCHAIN_FILE="/workspace/llvm-project/toolchain-x86_64-musl.cmake" \
+#    -DCMAKE_BUILD_TYPE=Release \
+#    -DCMAKE_C_COMPILER_TARGET=x86_64-linux-musl \
+#    -DCMAKE_CXX_COMPILER_TARGET=x86_64-linux-musl \
+#    -DLIBCXX_HAS_MUSL_LIBC=ON 
+
+#make -C build_x86_64_clang_musl
+#DESTDIR=/workspace/llvm-project/output_x86_64_clang_musl make -C build_x86_64_clang_musl install
+
+#Step 3c: Fix Clang runtime linking with patchelf
+#Use patchelf to set the correct runtime library paths:
+#
+#   patchelf --set-interpreter \
+#       /workspace/musl-cross-make/output-x86_64/x86_64-linux-musl/lib/libc.so \
+#       /workspace/llvm-project/output_x86_64_clang_musl/usr/local/bin/clang
+#
+#   patchelf --set-rpath \
+#       /workspace/musl-cross-make/output-x86_64/x86_64-linux-musl/lib \
+#       /workspace/llvm-project/output_x86_64_clang_musl/usr/local/bin/clang
+
+#Step 3d (optional). Test your Clang compiler
+#Compile a small C/C++ test file in verbose mode to verify that:
+#- The correct libraries are being used (musl is included instead of glibc)
+#./test_x86_64_clang.sh
+
+#4. Build Clang with runtimes for aarch64-musl
+#Step 4a: Create a CMake toolchain file toolchain-aarch64-musl.cmake
+#(See this file for full details)
+
+#Step 4b: Run your second CMake configuration to build Clang using musl
+#cmake -G "Unix Makefiles" -S llvm -B build_aarch64_clang_musl \
+#    -DLLVM_ENABLE_PROJECTS="clang" \
+#    -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \
+#    -DLLVM_ENABLE_LIBCXX=ON \
+#    -DLLVM_RUNTIME_TARGETS="aarch64-linux-musl" \
+#    -DCMAKE_TOOLCHAIN_FILE="/workspace/llvm-project/toolchain-aarch64-musl.cmake" \
+#    -DCMAKE_BUILD_TYPE=Release \
+#    -DCMAKE_C_COMPILER_TARGET=aarch64-linux-musl \
+#    -DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-musl \
+#    -DCXX_SUPPORTS_CXXABI=ON \
+#    -DLIBCXX_HAS_MUSL_LIBC=ON
+
+#make -C build_aarch64_clang_musl
+#DESTDIR=/workspace/llvm-project/output_aarch64_clang_musl make -C build_aarch64_clang_musl install
+
+#Step 4c: Fix Clang runtime linking with patchelf
+#Use patchelf to set the correct runtime library paths:
+#
+#   patchelf --set-interpreter \
+#       /workspace/musl-cross-make/output-aarch64/aarch64-linux-musl/lib/libc.so \
+#       /workspace/llvm-project/output_aarch64_clang_musl/usr/local/bin/clang
+#
+#   patchelf --set-rpath \
+#       /workspace/musl-cross-make/output-aarch64/aarch64-linux-musl/lib/ \
+#       /workspace/llvm-project/output_aarch64_clang_musl/usr/local/bin/clang
+
+#Step 4d (optional). Test libc++ with musl
+#Compile a small C++ program to verify that libc++ is using musl.
+#./test_aarch64_clang.sh
+
+#!/bin/bash
+set -ex
+
+# Variables
+PROC_NR=2
+#WORK_DIR="/home/victor/emb-linux/lnx5-sdk"
+WORK_DIR="/build"
+BUILD_TOOL="ninja"
+
+LD_MUSL_X86_64=ld-musl-x86_64.so.1
+LD_MUSL_AARCH64=ld-musl-aarch64.so.1
+X86_64_TARGET="x86_64-linux-musl"
+AARCH64_TARGET="aarch64-linux-musl"
+
+MUSL_CROSS_PROJECT_DIR="${WORK_DIR}/musl-cross-make"
+MUSL_CROSS_GIT_REPO="https://github.com/richfelker/musl-cross-make.git"
+GCC_VER="12.4.0"
+LINUX_VER="5.15.183"
+MUSL_X86_64_INSTALL_DIR="/usr/x86_64-linux-musl"
+MUSL_AARCH64_INSTALL_DIR="/usr/aarch64-linux-musl"
+
+LLVM_PROJECT_DIR="${WORK_DIR}/llvm-project"
+LLVM_GIT_REPO="https://github.com/llvm/llvm-project.git"
+LLVM_GIT_BRNCH="release/18.x"
+CLANG_X86_64_INSTALL_DIR="/usr/x86_64_clang_musl"
+CLANG_AARCH64_INSTALL_DIR="/usr/aarch64_clang_musl"
+
+
+check_tools() {
+    patchelf --version
+    cmake --version
+    make --version
+    /usr/bin/ld.lld --version
+    if [ "$BUILD_TOOL" = "ninja" ]; then
+        ninja --version
+    else 
+        exit 1
+    fi
+}
+
+clone_musl() {
+    cd $WORK_DIR
+    if [ ! -d "$MUSL_CROSS_PROJECT_DIR" ]; then
+        git clone $MUSL_CROSS_GIT_REPO
+        cd $MUSL_CROSS_PROJECT_DIR
+        git config --global --add safe.directory $MUSL_CROSS_PROJECT_DIR
+        git config --global user.email "inquiries@elektrobit.com"
+        git config --global user.name "Elektrobit"
+        git am $WORK_DIR/0001-musl-cross-add-linux-5.15.183-hash.patch
+    fi
+}
+
+build_musl_target() {
+    local target=$1
+    local install_dir=$2
+
+    cd $MUSL_CROSS_PROJECT_DIR
+
+    cat > config.mak <<EOF
+TARGET=${target}
+GCC_VER=${GCC_VER}
+MUSL_VER=1.2.5
+BINUTILS_VER=2.33.1
+LINUX_VER=${LINUX_VER}
+OUTPUT=${install_dir}
+EOF
+
+    make -j$PROC_NR
+}
+
+install_musl_target() {
+    local target=$1
+    local install_dir=$2
+    local ld_musl=$3
+
+    cd $MUSL_CROSS_PROJECT_DIR
+
+    rm -frd "$install_dir"
+    make install
+
+    cd "$install_dir"
+    if [ -d "$target" ]; then
+        cd "$target/lib"
+        rm -f "$ld_musl"
+        ln -s libc.so "$ld_musl"
+        cd -
+    fi
+
+    local gcc_dir="$install_dir/lib/gcc/$target/$GCC_VER"
+    if [ -d "$gcc_dir" ]; then
+        for f in "$install_dir/lib/libcc1"*; do
+            [ -e "$f" ] && mv "$f" "$gcc_dir"
+        done
+        ln -sf $gcc_dir/* $install_dir/$target/lib
+    fi
+}
+
+
+clone_llvm() {
+    cd $WORK_DIR
+    if [ ! -d "$LLVM_PROJECT_DIR" ]; then
+        git clone --depth 1 --branch $LLVM_GIT_BRNCH $LLVM_GIT_REPO
+        cd $LLVM_PROJECT_DIR
+        git config --global --add safe.directory $LLVM_PROJECT_DIR
+        git config --global user.email "inquiries@elektrobit.com"
+        git config --global user.name "Elektrobit"
+        git am $WORK_DIR/0001-llvm-enable-by-default-musl-libc.patch
+    fi
+}
+
+build_clang_target() {
+    local target=$1
+    local musl_dir=$2
+    local compiler_dir=$3
+    local build_dir=$4
+    local toolchain_file="$LLVM_PROJECT_DIR/${target}-toolchain.cmake"
+
+    local cm_build_tool=""
+    if [ "$BUILD_TOOL" = "ninja" ]; then
+        cm_build_tool="Ninja"
+    elif [ "$BUILD_TOOL" = "make" ]; then
+        cm_build_tool="Unix Makefiles"
+    else
+        exit 1
+    fi
+
+    cd $LLVM_PROJECT_DIR
+   
+
+    if [ "$target" = "x86_64-linux-musl" ]; then
+        cat > "$toolchain_file" <<EOF
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR ${target%%-*})
+set(CMAKE_C_COMPILER ${compiler_dir}/bin/${target}-gcc)
+set(CMAKE_CXX_COMPILER ${compiler_dir}/bin/${target}-g++)
+set(CMAKE_C_COMPILER_TARGET ${target})
+set(CMAKE_CXX_COMPILER_TARGET ${target})
+set(CMAKE_SYSROOT ${musl_dir})
+set(CMAKE_FIND_ROOT_PATH ${musl_dir})
+EOF
+
+    cmake -G $cm_build_tool -S llvm -B "$build_dir" \
+        -DLLVM_ENABLE_PROJECTS="clang" \
+        -DCMAKE_TOOLCHAIN_FILE="$toolchain_file" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLIBCXX_HAS_MUSL_LIBC=ON
+
+    elif [ "$target" = "aarch64-linux-musl" ]; then
+        cat > "$toolchain_file" <<EOF1
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR ${target%%-*})
+set(CMAKE_C_COMPILER ${compiler_dir}/usr/local/bin/clang)
+set(CMAKE_CXX_COMPILER ${compiler_dir}/usr/local/bin/clang++)
+set(CMAKE_LINKER /usr/bin/lld)
+set(CMAKE_C_COMPILER_TARGET ${target})
+set(CMAKE_CXX_COMPILER_TARGET ${target})
+set(CMAKE_SYSROOT ${musl_dir})
+set(CMAKE_FIND_ROOT_PATH ${musl_dir})
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld")
+set(CMAKE_MODULE_LINKER_FLAGS_INIT "-fuse-ld=lld")
+EOF1
+
+    cmake -G $cm_build_tool -S llvm -B "$build_dir" \
+        -DLLVM_ENABLE_PROJECTS="clang" \
+        -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \
+        -DLLVM_ENABLE_LIBCXX=ON \
+        -DLLVM_RUNTIME_TARGETS="${target}" \
+        -DCMAKE_TOOLCHAIN_FILE="$toolchain_file" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCXX_SUPPORTS_CXXABI=ON \
+        -DLIBCXX_HAS_MUSL_LIBC=ON 
+    fi
+
+    $BUILD_TOOL -j$PROC_NR -C "$build_dir"
+}
+
+install_clang_target() {
+    local clang_install_dir=$1
+    local build_dir=$2
+
+    cd $LLVM_PROJECT_DIR
+
+    rm -frd "$clang_install_dir"
+    DESTDIR="$clang_install_dir" $BUILD_TOOL -C "$build_dir" install
+}
+
+patch_clang_bins() {
+    local install_dir=$1
+    local ld_path=$2
+
+    if [ -d "$install_dir/usr/local/bin" ]; then
+        for f in "$install_dir/usr/local/bin/"*; do
+            if [ -x "$f" ] && file "$f" | grep -q "ELF"; then
+                patchelf --set-interpreter "$ld_path" "$f"
+                patchelf --set-rpath "$(dirname "$ld_path")" "$f"
+            fi
+        done
+    fi
+}
+
+clean_all() {
+    rm -frd $MUSL_CROSS_PROJECT_DIR
+    rm -frd $LLVM_PROJECT_DIR
+}
+
+main() {
+    case "$1" in
+        --check_tools)
+            check_tools
+            ;;
+        --clone_musl)
+            clone_musl
+            ;;
+        --build_musl_x86)
+            build_musl_target "$X86_64_TARGET" "$MUSL_X86_64_INSTALL_DIR"
+            ;;
+        --install_musl_x86)
+            install_musl_target "$X86_64_TARGET" "$MUSL_X86_64_INSTALL_DIR" "$LD_MUSL_X86_64"
+            ;;
+        --clone_llvm)
+            clone_llvm
+            ;;
+        --build_clang_x86)
+            build_clang_target "$X86_64_TARGET" "$MUSL_X86_64_INSTALL_DIR" "$MUSL_X86_64_INSTALL_DIR" "build_x86_64_clang_musl"
+            ;;
+        --install_clang_x86)
+            install_clang_target "$CLANG_X86_64_INSTALL_DIR" "build_x86_64_clang_musl"
+            patch_clang_bins "$CLANG_X86_64_INSTALL_DIR" "$MUSL_X86_64_INSTALL_DIR/$X86_64_TARGET/lib/$LD_MUSL_X86_64"
+            ;;
+        --build_musl_aarch64)
+            build_musl_target "$AARCH64_TARGET" "$MUSL_AARCH64_INSTALL_DIR"
+            ;;
+        --install_musl_aarch64)
+            install_musl_target "$AARCH64_TARGET" "$MUSL_AARCH64_INSTALL_DIR" "$LD_MUSL_AARCH64"
+            ;;
+        --build_clang_aarch64)
+            build_clang_target "$AARCH64_TARGET" "$MUSL_AARCH64_INSTALL_DIR" "$CLANG_X86_64_INSTALL_DIR" "build_aarch64_clang_musl"
+            ;;
+        --install_clang_aarch64)
+            install_clang_target "$CLANG_AARCH64_INSTALL_DIR" "build_aarch64_clang_musl"
+            patch_clang_bins "$CLANG_AARCH64_INSTALL_DIR" "$MUSL_AARCH64_INSTALL_DIR/$AARCH64_TARGET/lib/$LD_MUSL_AARCH64"
+            ;;
+        --all)
+            check_tools
+            clone_musl
+            clone_llvm
+            
+            build_musl_target "$X86_64_TARGET" "$MUSL_X86_64_INSTALL_DIR"
+            install_musl_target "$X86_64_TARGET" "$MUSL_X86_64_INSTALL_DIR" "$LD_MUSL_X86_64"
+            build_musl_target "$AARCH64_TARGET" "$MUSL_AARCH64_INSTALL_DIR"
+            install_musl_target "$AARCH64_TARGET" "$MUSL_AARCH64_INSTALL_DIR" "$LD_MUSL_AARCH64"
+            build_clang_target "$X86_64_TARGET" "$MUSL_X86_64_INSTALL_DIR" "$MUSL_X86_64_INSTALL_DIR" "build_x86_64_clang_musl"
+            install_clang_target "$CLANG_X86_64_INSTALL_DIR" "build_x86_64_clang_musl"
+            patch_clang_bins "$CLANG_X86_64_INSTALL_DIR" "$MUSL_X86_64_INSTALL_DIR/$X86_64_TARGET/lib/$LD_MUSL_X86_64"
+            build_clang_target "$AARCH64_TARGET" "$MUSL_AARCH64_INSTALL_DIR" "$CLANG_X86_64_INSTALL_DIR" "build_aarch64_clang_musl"
+            install_clang_target "$CLANG_AARCH64_INSTALL_DIR" "build_aarch64_clang_musl"
+            patch_clang_bins "$CLANG_AARCH64_INSTALL_DIR" "$MUSL_AARCH64_INSTALL_DIR/$AARCH64_TARGET/lib/$LD_MUSL_AARCH64"
+            ;;
+        --clean)
+            clean_all
+            ;;
+        *)
+            echo "Usage: $0 [--x86|--aarch64|--clean]"
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/layers/ebclfsa/conf/scripts/build_clang_libc++_musl.sh
+++ b/layers/ebclfsa/conf/scripts/build_clang_libc++_musl.sh
@@ -104,9 +104,10 @@
 #!/bin/bash
 set -ex
 
+export LLVM_SYMBOLIZER_PATH=/usr/lib/llvm-18/bin/llvm-symbolizer
+
 # Variables
 PROC_NR=2
-#WORK_DIR="/home/victor/emb-linux/lnx5-sdk"
 WORK_DIR="/build"
 BUILD_TOOL="ninja"
 


### PR DESCRIPTION
Added initial patches for enabling build of musl-libc and kernel header for linux-5.15.183

Created build_clang_libc++_musl.sh to automate Clang + libc++ + musl toolchain build

Updated CMake toolchain file to support Clang-18 and libc++ with musl runtime

Updated Dockerfile to manage clean installation of Clang-18 with libc++ and musl-libc