### PR TITLE
fix: read Version_packages from config file

### DIFF
--- a/builder/build_container.py
+++ b/builder/build_container.py
@@ -43,6 +43,7 @@ class ContainerBuilder:
         
         if self.config:
             self.version = self.config.get('Version', 'unknown')
+            self.version_packages = self.config.get('Version_packages', 'unknown')
 
     def _set_builder(self) -> None:
         """ Get the build tool form the environment. """


### PR DESCRIPTION
Until now, the variable Version_packages was not read from the configuration/build_config.yaml file during container build.
