### PR TITLE
fix: pin pip dependencies

### DIFF
--- a/layers/base/Dockerfile
+++ b/layers/base/Dockerfile
@@ -143,7 +143,9 @@ ENV VIRTUAL_ENV=/build/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-RUN pip install mypy pep8 pylint pytest pytest-cov robotframework
+COPY requirements.txt /tmp/requirements.txt
+
+RUN pip install -r /tmp/requirements.txt
 
 # Ensure venv owner
 USER root

--- a/layers/base/requirements.txt
+++ b/layers/base/requirements.txt
@@ -1,0 +1,6 @@
+mypy==1.19.1
+pep8==1.7.1
+pylint==4.0.4
+pytest==9.0.2
+pytest-cov==7.0.0
+robotframework==7.3.2 ## WARNING: 7.4 has a bug which breaks our tests


### PR DESCRIPTION
Installing dependencies via pip implicitly uses "latest". In this case, "latest" for robotframework broke our tests due to a bug introduced in version 7.4.

Generally, dependencies shall be pinned. Otherwise, all hell breaks loose.
